### PR TITLE
Sync exercise.html from Ursinus-WebIDE PR #11

### DIFF
--- a/exercise.html
+++ b/exercise.html
@@ -459,6 +459,523 @@ button:focus, input:focus, select:focus, .tab:focus {
     border-radius: 3px; border: 1px solid #3a3a3a;
 }
 
+/* ============================================================
+   INSPECTOR PANEL — variables, step-through, call-tape
+   ============================================================ */
+#inspector-panel { display: none; }
+#inspector-panel.active { display: flex; flex-direction: column; }
+#inspector-toolbar {
+    display: flex; align-items: center; gap: 2px;
+    padding: 4px; background: #1f1f1f; border-bottom: 1px solid #2d2d2d;
+    flex-shrink: 0;
+}
+.inspector-subtab {
+    padding: 3px 10px; background: transparent; color: #a0a0a0;
+    border: 1px solid transparent; border-radius: 3px;
+    cursor: pointer; font-size: 11px; text-transform: uppercase;
+    letter-spacing: 0.5px; font-weight: 600;
+}
+.inspector-subtab:hover { color: #ccc; background: #2a2a2a; }
+.inspector-subtab.active { color: #fff; background: #094771; }
+body[data-theme="light"] #inspector-toolbar { background: #f0f0f0; border-bottom-color: #d0d0d0; }
+body[data-theme="light"] .inspector-subtab { color: #444; }
+body[data-theme="light"] .inspector-subtab:hover { background: #e0e0e0; color: #000; }
+body[data-theme="light"] .inspector-subtab.active { background: #cfdcec; color: #000; }
+body[data-theme="hc"] .inspector-subtab.active { background: #ffd700; color: #000; }
+#inspector-body { flex: 1; overflow: auto; padding: 6px 8px; min-height: 0; }
+.inspector-view { display: none; }
+.inspector-view.active { display: block; }
+.inspector-empty {
+    padding: 18px; text-align: center; color: #888; font-size: 12px; line-height: 1.5;
+}
+/* Variables view */
+.inspector-var-row {
+    display: grid; grid-template-columns: minmax(120px, 24%) 80px 1fr;
+    gap: 8px; padding: 4px 6px; border-bottom: 1px dashed rgba(255,255,255,0.05);
+    font-family: 'Consolas', 'Courier New', monospace; font-size: 12px;
+    align-items: baseline;
+}
+body[data-theme="light"] .inspector-var-row { border-bottom-color: rgba(0,0,0,0.06); }
+.inspector-var-name { color: #9cdcfe; word-break: break-word; }
+.inspector-var-type { color: #ce9178; font-style: italic; font-size: 11px; }
+.inspector-var-value {
+    color: #d4d4d4; white-space: pre-wrap; word-break: break-word;
+    overflow: hidden; text-overflow: ellipsis;
+}
+body[data-theme="light"] .inspector-var-name { color: #006bb3; }
+body[data-theme="light"] .inspector-var-type { color: #b35900; }
+body[data-theme="light"] .inspector-var-value { color: #222; }
+/* Step-through view */
+#inspector-steps .step-controls {
+    display: flex; gap: 6px; align-items: center;
+    padding: 6px 4px 10px; border-bottom: 1px solid rgba(255,255,255,0.06);
+    flex-wrap: wrap;
+}
+.step-btn {
+    padding: 3px 10px; background: #3a3a3a; color: #ccc;
+    border: 1px solid #555; border-radius: 3px; cursor: pointer;
+    font-size: 12px; min-width: 32px;
+}
+.step-btn:hover:not(:disabled) { background: #4a4a4a; color: #fff; }
+.step-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.step-progress {
+    flex: 1; min-width: 80px; font-size: 11px; color: #a0a0a0;
+    font-family: 'Consolas', monospace;
+}
+.step-display {
+    margin-top: 8px;
+    display: grid; grid-template-columns: 1fr 1fr; gap: 8px;
+}
+@media (max-width: 700px) { .step-display { grid-template-columns: 1fr; } }
+.step-pane {
+    background: #1a1a1a; border: 1px solid #2d2d2d; border-radius: 3px;
+    padding: 6px 8px; font-family: 'Consolas', monospace; font-size: 12px;
+    min-height: 60px;
+}
+body[data-theme="light"] .step-pane { background: #fafafa; border-color: #d0d0d0; }
+.step-pane h5 {
+    margin: 0 0 4px; font-size: 10px; text-transform: uppercase;
+    color: #9cdcfe; letter-spacing: 1px; font-weight: 700;
+}
+body[data-theme="light"] .step-pane h5 { color: #006bb3; }
+.step-locals .inspector-var-row { padding: 2px 0; border: none; }
+.step-line-display {
+    margin-top: 4px; padding: 4px 6px; background: #0e0e0e;
+    border-left: 3px solid #75beff; color: #ccc; word-break: break-word;
+}
+body[data-theme="light"] .step-line-display { background: #fff; color: #222; }
+.step-line-num { color: #888; margin-right: 8px; font-size: 11px; }
+/* Call-tape view */
+.calltape-tree { font-family: 'Consolas', monospace; font-size: 12px; line-height: 1.5; }
+.calltape-node {
+    margin-left: 16px; padding-left: 8px;
+    border-left: 1px dotted rgba(255,255,255,0.15);
+}
+body[data-theme="light"] .calltape-node { border-left-color: rgba(0,0,0,0.18); }
+.calltape-call { color: #d4d4d4; }
+.calltape-fname { color: #dcdcaa; font-weight: 600; }
+body[data-theme="light"] .calltape-fname { color: #795e26; }
+.calltape-args { color: #9cdcfe; }
+.calltape-arrow { color: #888; margin: 0 4px; }
+.calltape-return { color: #b5cea8; }
+body[data-theme="light"] .calltape-return { color: #098658; }
+.calltape-throw { color: #f48771; }
+.calltape-unclosed { color: #cca700; font-style: italic; margin-left: 6px; font-size: 11px; }
+body[data-theme="light"] .calltape-unclosed { color: #a36b00; }
+body[data-theme="hc"] .calltape-unclosed { color: #ffd700; }
+.calltape-toggle {
+    display: inline-block; width: 12px; cursor: pointer; user-select: none;
+    color: #888; margin-right: 2px;
+}
+.calltape-children.collapsed { display: none; }
+.calltape-summary {
+    padding: 6px 8px; background: #1a1a1a; border-radius: 3px;
+    margin-bottom: 8px; font-size: 11px; color: #a0a0a0;
+}
+body[data-theme="light"] .calltape-summary { background: #f0f0f0; color: #444; }
+
+/* Multi-line code example shown in the Call-Tape empty-state. */
+.webide-code-block {
+    font-family: 'Consolas', 'Courier New', monospace;
+    font-size: 11.5px; line-height: 1.45;
+    background: rgba(255,255,255,0.04);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 4px;
+    padding: 10px 12px;
+    margin: 8px 0 12px;
+    white-space: pre-wrap;
+    overflow-x: auto;
+    color: #d4d4d4;
+}
+.webide-code-block strong {
+    color: #dcdcaa;
+    font-weight: 700;
+}
+body[data-theme="light"] .webide-code-block {
+    background: rgba(0,0,0,0.04);
+    border-color: rgba(0,0,0,0.08);
+    color: #1f1f1f;
+}
+body[data-theme="light"] .webide-code-block strong { color: #795e26; }
+body[data-theme="hc"] .webide-code-block {
+    background: #000; border: 1px solid #ffd700; color: #fff;
+}
+body[data-theme="hc"] .webide-code-block strong { color: #ffd700; }
+
+/* Inline code chip used in UI hints (empty-states, menus). The default cyan
+   reads fine on the dark theme but disappears on the light-theme white
+   background, so we set a theme-appropriate fg+bg here. */
+.code-inline {
+    font-family: 'Consolas', 'Courier New', monospace;
+    font-size: 11px;
+    color: #9cdcfe;
+    background: rgba(255, 255, 255, 0.08);
+    padding: 1px 5px;
+    border-radius: 3px;
+    white-space: nowrap;
+}
+body[data-theme="light"] .code-inline { color: #006bb3; background: rgba(0, 0, 0, 0.06); }
+body[data-theme="hc"]    .code-inline { color: #ffd700; background: #000; border: 1px solid #ffd700; }
+
+/* Right-aligned menu-item value (Theme: Dark, Font Size: 14, etc.). Same
+   problem as code-inline — the dropdown's background flips between themes. */
+.menu-value {
+    color: #9cdcfe;
+    margin-left: 4px;
+}
+body[data-theme="light"] .menu-value { color: #006bb3; }
+body[data-theme="hc"]    .menu-value { color: #ffd700; }
+/* ACE marker for the currently-stepped line */
+.ace_editor .webide-step-marker {
+    position: absolute; background: rgba(255, 215, 0, 0.18); z-index: 4;
+}
+body[data-theme="hc"] .ace_editor .webide-step-marker { background: rgba(255, 215, 0, 0.5); }
+
+/* Gutter breakpoint dot. Ace's setBreakpoint(row, cls) puts our class on the
+   gutter cell; we draw a red circle inside it. Color-blind users also see a
+   thin border outline + tooltip. The cell becomes click-target via .ace_gutter
+   pointer-events:auto (Ace's default already allows clicks). */
+.ace_editor .ace_gutter-cell.webide-breakpoint {
+    position: relative;
+}
+.ace_editor .ace_gutter-cell.webide-breakpoint::before {
+    content: '';
+    position: absolute;
+    left: 4px; top: 50%;
+    width: 10px; height: 10px;
+    margin-top: -5px;
+    border-radius: 50%;
+    background: #e51400;
+    box-shadow: 0 0 0 1px rgba(0,0,0,0.3);
+}
+body[data-theme="hc"] .ace_editor .ace_gutter-cell.webide-breakpoint::before {
+    background: #ffd700;
+    box-shadow: 0 0 0 2px #000;
+}
+body[data-colorblind="true"] .ace_editor .ace_gutter-cell.webide-breakpoint::before {
+    background: #cc3311;
+    border: 2px solid #fff;
+}
+/* Hover affordance on the gutter so students know it's clickable. */
+.ace_editor .ace_gutter:hover { cursor: pointer; }
+/* The "paused at this line" highlight is a brighter version of the step marker. */
+.ace_editor .webide-pause-marker {
+    position: absolute; background: rgba(229, 20, 0, 0.22); z-index: 5;
+}
+body[data-theme="hc"] .ace_editor .webide-pause-marker { background: rgba(255, 215, 0, 0.55); }
+
+/* Run-history + Preflight dialogs — same modal scaffolding as the
+   shortcuts overlay so they pick up theme + reading-mode CSS. */
+#run-history-dialog, #preflight-dialog {
+    position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0,0,0,0.55); z-index: 9998;
+    display: none; align-items: center; justify-content: center; padding: 20px;
+}
+#run-history-dialog.visible, #preflight-dialog.visible { display: flex; }
+.webide-modal-box {
+    background: #252526; border: 1px solid #454545; color: #ccc;
+    width: min(640px, 100%); max-height: 85vh; overflow: auto;
+    border-radius: 6px; box-shadow: 4px 8px 24px rgba(0,0,0,0.7);
+}
+body[data-theme="light"] .webide-modal-box { background: #fff; color: #222; border-color: #b8b8b8; }
+body[data-theme="hc"] .webide-modal-box { background: #000; color: #fff; border: 2px solid #ffd700; }
+
+/* Tests panel rows — pass/fail with shape-distinguishable icons that
+   read well even in color-blind mode. */
+.test-row {
+    display: flex; align-items: flex-start; gap: 6px;
+    padding: 4px 0; border-bottom: 1px solid rgba(255,255,255,0.06);
+    font-size: 12px; line-height: 1.4;
+}
+.test-row.pass .test-icon { color: #3fb950; }
+.test-row.fail .test-icon { color: #f85149; }
+.test-row.pending .test-icon { color: #d29922; }
+.test-row.error .test-icon { color: #f85149; }
+body[data-colorblind="true"] .test-row.pass .test-icon::after { content: " (PASS)"; font-size: 10px; }
+body[data-colorblind="true"] .test-row.fail .test-icon::after { content: " (FAIL)"; font-size: 10px; }
+.test-icon { width: 14px; text-align: center; font-weight: 700; flex-shrink: 0; }
+.test-name { flex: 1; word-break: break-word; }
+.test-detail {
+    margin: 4px 0 4px 22px; padding: 4px 6px;
+    background: rgba(0,0,0,0.25); border-left: 2px solid #f85149;
+    font-family: 'Consolas', 'Courier New', monospace; font-size: 11px;
+    white-space: pre-wrap; word-break: break-word;
+}
+body[data-theme="light"] .test-detail { background: #fff5f5; color: #5a1d1d; }
+
+/* ============================================================
+   PREFERENCES — Themes, font size, reading mode (dyslexia-friendly)
+   Driven by data-attributes on <body> set by applyPrefs() in JS.
+   localStorage key: 'webide.prefs' (JSON).
+   ============================================================ */
+
+/* Light theme — overrides the dark surface colors.
+   Targeted overrides only; full IDE colors come from inline rules above. */
+body[data-theme="light"] {
+    background: #f5f5f5; color: #222;
+}
+body[data-theme="light"] html,
+body[data-theme="light"] {
+    background: #f5f5f5 !important; color: #222;
+}
+body[data-theme="light"] #vscode-ide,
+body[data-theme="light"] #ide-editor-area,
+body[data-theme="light"] #ide-editor-main,
+body[data-theme="light"] #editor-container,
+body[data-theme="light"] #ide-bottom-panel,
+body[data-theme="light"] #terminal-container,
+body[data-theme="light"] #output-container,
+body[data-theme="light"] #console,
+body[data-theme="light"] #media-area,
+body[data-theme="light"] #submit-view {
+    background: #f5f5f5; color: #222;
+}
+body[data-theme="light"] #ide-titlebar { background: #e6e6e6; border-bottom-color: #c8c8c8; }
+body[data-theme="light"] #ide-tabs-bar,
+body[data-theme="light"] #bottom-tabs-bar { background: #ececec; border-bottom-color: #c8c8c8; }
+body[data-theme="light"] #ide-activity-bar { background: #dddddd; border-right-color: #c8c8c8; }
+body[data-theme="light"] #ide-sidebar { background: #ebebeb; border-right-color: #c8c8c8; }
+body[data-theme="light"] .menu-item,
+body[data-theme="light"] .menu-dropdown-item,
+body[data-theme="light"] .tab,
+body[data-theme="light"] .bottom-tab,
+body[data-theme="light"] .activity-icon { color: #222; }
+body[data-theme="light"] .menu-item:hover,
+body[data-theme="light"] .menu-item.open { background: #cfdcec; }
+body[data-theme="light"] .menu-dropdown { background: #ffffff; border-color: #c8c8c8; box-shadow: 3px 4px 12px rgba(0,0,0,0.18); }
+body[data-theme="light"] .menu-dropdown-item:hover { background: #cfdcec; color: #000; }
+body[data-theme="light"] .tab { background: #ececec; color: #444; border-right-color: #d2d2d2; }
+body[data-theme="light"] .tab.active { background: #ffffff; color: #000; }
+body[data-theme="light"] .bottom-tab.active { color: #000; border-bottom-color: #007acc; }
+body[data-theme="light"] .sidebar-header { color: #444; }
+body[data-theme="light"] .sidebar-form input[type="text"],
+body[data-theme="light"] .sidebar-form input[type="password"],
+body[data-theme="light"] .gh-select {
+    background: #fff; color: #222; border-color: #b8b8b8;
+}
+body[data-theme="light"] .info-panel-content,
+body[data-theme="light"] .info-panel-content h2,
+body[data-theme="light"] .info-panel-content h3,
+body[data-theme="light"] .info-panel-content a { color: #222; }
+body[data-theme="light"] .info-panel-content h2 { color: #0066aa; }
+body[data-theme="light"] .info-panel-content h3 { color: #b35900; }
+body[data-theme="light"] .info-panel-content a { color: #006bb3; }
+body[data-theme="light"] .info-divider { border-top-color: #c8c8c8; }
+body[data-theme="light"] #ide-status-bar { background: #007acc; color: #fff; }
+body[data-theme="light"] .action-btn { background: #ffffff; color: #222; border-color: #b8b8b8; }
+body[data-theme="light"] .action-btn:hover:not(:disabled) { background: #e9e9e9; color: #000; }
+body[data-theme="light"] .action-btn.run-btn { background: #2f8c2c; color: #fff; }
+body[data-theme="light"] .action-btn.run-btn:hover:not(:disabled) { background: #3aa336; }
+body[data-theme="light"] #ide-input-box { background: #fff; border-color: #b8b8b8; }
+body[data-theme="light"] #ide-input-label { color: #444; }
+body[data-theme="light"] #ide-input-field { background: #fff; color: #111; }
+body[data-theme="light"] .activity-icon { color: #555; }
+body[data-theme="light"] .activity-icon:hover { color: #111; }
+body[data-theme="light"] .activity-icon.active { color: #000; border-left-color: #007acc; }
+body[data-theme="light"] .suggestion-item { background: #ffffff; }
+body[data-theme="light"] .suggestion-item:hover { background: #ececec; }
+body[data-theme="light"] .suggestion-message { color: #111; }
+/* Editor (ACE) tokens for light theme — overrides monokai colors via CSS */
+body[data-theme="light"] .ace_editor,
+body[data-theme="light"] .ace_editor .ace_gutter,
+body[data-theme="light"] .ace_editor .ace_scroller { background: #ffffff !important; color: #1f1f1f !important; }
+body[data-theme="light"] .ace_editor .ace_gutter { color: #888 !important; border-right: 1px solid #e0e0e0; }
+body[data-theme="light"] .ace_editor .ace_keyword,
+body[data-theme="light"] .ace_editor .ace_storage { color: #af00db !important; }
+body[data-theme="light"] .ace_editor .ace_string { color: #a31515 !important; }
+body[data-theme="light"] .ace_editor .ace_constant,
+body[data-theme="light"] .ace_editor .ace_constant.ace_numeric { color: #098658 !important; }
+body[data-theme="light"] .ace_editor .ace_comment { color: #008000 !important; font-style: italic; }
+body[data-theme="light"] .ace_editor .ace_function,
+body[data-theme="light"] .ace_editor .ace_entity.ace_name.ace_function { color: #795e26 !important; }
+body[data-theme="light"] .ace_editor .ace_variable,
+body[data-theme="light"] .ace_editor .ace_identifier { color: #1f1f1f !important; }
+body[data-theme="light"] .ace_editor .ace_cursor { color: #000 !important; }
+body[data-theme="light"] .ace_editor .ace_marker-layer .ace_selection { background: #add6ff !important; }
+body[data-theme="light"] .ace_editor .ace_active-line { background: #f3f3f3 !important; }
+
+/* High-contrast theme — black/white/yellow for low-vision users (WCAG AAA-ish) */
+body[data-theme="hc"] {
+    background: #000000 !important; color: #ffffff;
+}
+body[data-theme="hc"] #vscode-ide,
+body[data-theme="hc"] #ide-editor-area,
+body[data-theme="hc"] #ide-editor-main,
+body[data-theme="hc"] #editor-container,
+body[data-theme="hc"] #ide-bottom-panel,
+body[data-theme="hc"] #terminal-container,
+body[data-theme="hc"] #output-container,
+body[data-theme="hc"] #console,
+body[data-theme="hc"] #media-area,
+body[data-theme="hc"] #submit-view {
+    background: #000000; color: #ffffff;
+}
+body[data-theme="hc"] #ide-titlebar { background: #000; border-bottom: 2px solid #ffffff; }
+body[data-theme="hc"] #ide-tabs-bar,
+body[data-theme="hc"] #bottom-tabs-bar { background: #000; border-bottom: 2px solid #ffffff; }
+body[data-theme="hc"] #ide-activity-bar { background: #000; border-right: 2px solid #ffffff; }
+body[data-theme="hc"] #ide-sidebar { background: #000; border-right: 2px solid #ffffff; }
+body[data-theme="hc"] .menu-item,
+body[data-theme="hc"] .menu-dropdown-item,
+body[data-theme="hc"] .tab,
+body[data-theme="hc"] .bottom-tab,
+body[data-theme="hc"] .activity-icon,
+body[data-theme="hc"] .info-panel-content,
+body[data-theme="hc"] .sidebar-header { color: #ffffff; }
+body[data-theme="hc"] .menu-item:hover,
+body[data-theme="hc"] .menu-item.open { background: #1a1a1a; outline: 2px solid #ffd700; }
+body[data-theme="hc"] .menu-dropdown { background: #000; border: 2px solid #ffffff; }
+body[data-theme="hc"] .menu-dropdown-item:hover { background: #ffd700; color: #000; }
+body[data-theme="hc"] .tab.active { background: #1a1a1a; color: #ffffff; border-top-color: #ffd700; }
+body[data-theme="hc"] .bottom-tab.active { color: #ffd700; border-bottom-color: #ffd700; }
+body[data-theme="hc"] .action-btn { background: #000; color: #fff; border: 2px solid #fff; }
+body[data-theme="hc"] .action-btn:hover:not(:disabled) { background: #ffd700; color: #000; }
+body[data-theme="hc"] .action-btn.run-btn { background: #ffd700; color: #000; border-color: #ffd700; font-weight: 700; }
+body[data-theme="hc"] .action-btn.run-btn:hover:not(:disabled) { background: #fff; color: #000; }
+body[data-theme="hc"] #ide-status-bar { background: #ffd700; color: #000; }
+body[data-theme="hc"] button:focus, body[data-theme="hc"] input:focus,
+body[data-theme="hc"] select:focus, body[data-theme="hc"] .tab:focus,
+body[data-theme="hc"] [tabindex]:focus, body[data-theme="hc"] a:focus { outline: 3px solid #ffd700 !important; outline-offset: 2px; }
+body[data-theme="hc"] .ace_editor,
+body[data-theme="hc"] .ace_editor .ace_gutter,
+body[data-theme="hc"] .ace_editor .ace_scroller { background: #000 !important; color: #fff !important; }
+body[data-theme="hc"] .ace_editor .ace_gutter { color: #fff !important; border-right: 2px solid #fff; }
+body[data-theme="hc"] .ace_editor .ace_keyword,
+body[data-theme="hc"] .ace_editor .ace_storage { color: #ffd700 !important; font-weight: 700; }
+body[data-theme="hc"] .ace_editor .ace_string { color: #ffffff !important; text-decoration: underline; }
+body[data-theme="hc"] .ace_editor .ace_constant,
+body[data-theme="hc"] .ace_editor .ace_constant.ace_numeric { color: #00ff00 !important; }
+body[data-theme="hc"] .ace_editor .ace_comment { color: #cccccc !important; font-style: italic; }
+body[data-theme="hc"] .ace_editor .ace_function,
+body[data-theme="hc"] .ace_editor .ace_entity.ace_name.ace_function { color: #00ffff !important; }
+body[data-theme="hc"] .ace_editor .ace_cursor { color: #ffd700 !important; border-left: 2px solid #ffd700 !important; }
+body[data-theme="hc"] .ace_editor .ace_marker-layer .ace_selection { background: #ffd700 !important; color: #000; }
+body[data-theme="hc"] .ace_editor .ace_active-line { background: #1a1a1a !important; }
+
+/* Reading mode: dyslexia-friendly typography (no external font required).
+   Uses font-family stack that prefers OpenDyslexic/Atkinson if installed locally,
+   falls back to a clean sans + extra letter spacing + larger line height. */
+body[data-readingmode="dyslexia"],
+body[data-readingmode="dyslexia"] .menu-item,
+body[data-readingmode="dyslexia"] .menu-dropdown-item,
+body[data-readingmode="dyslexia"] .tab,
+body[data-readingmode="dyslexia"] .bottom-tab,
+body[data-readingmode="dyslexia"] .info-panel-content,
+body[data-readingmode="dyslexia"] .sidebar-form,
+body[data-readingmode="dyslexia"] .sidebar-form p,
+body[data-readingmode="dyslexia"] .sidebar-form label,
+body[data-readingmode="dyslexia"] .form-status,
+body[data-readingmode="dyslexia"] .action-btn,
+body[data-readingmode="dyslexia"] .form-btn,
+body[data-readingmode="dyslexia"] #ide-input-label,
+body[data-readingmode="dyslexia"] #ide-status-bar,
+body[data-readingmode="dyslexia"] #ide-title-center {
+    font-family: "OpenDyslexic", "Atkinson Hyperlegible", "Comic Sans MS",
+                 "Verdana", "Tahoma", -apple-system, sans-serif !important;
+    letter-spacing: 0.04em;
+    word-spacing: 0.08em;
+}
+body[data-readingmode="dyslexia"] .info-panel-content,
+body[data-readingmode="dyslexia"] .sidebar-form p { line-height: 1.7; }
+body[data-readingmode="dyslexia"] .ace_editor {
+    font-family: "OpenDyslexic Mono", "Atkinson Hyperlegible Mono",
+                 "Cascadia Code", "Consolas", monospace !important;
+    letter-spacing: 0.02em;
+    line-height: 1.6 !important;
+}
+
+/* Focus-visible enhancement (WCAG 2.4.7) — only show outlines on keyboard focus,
+   not on mouse-click. The existing :focus rule remains as a fallback for older browsers. */
+button:focus-visible, input:focus-visible, select:focus-visible,
+textarea:focus-visible, .tab:focus-visible, [tabindex]:focus-visible,
+a:focus-visible {
+    outline: 2px solid #ffd700 !important;
+    outline-offset: 2px;
+    z-index: 1;
+}
+button:focus:not(:focus-visible),
+input:focus:not(:focus-visible),
+select:focus:not(:focus-visible) {
+    outline: none !important;
+}
+
+/* ============================================================
+   KEYBOARD SHORTCUT OVERLAY — modeled on #ide-input-dialog
+   ============================================================ */
+#ide-shortcuts-overlay {
+    position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0,0,0,0.55); z-index: 9998;
+    display: none; align-items: center; justify-content: center; padding: 20px;
+}
+#ide-shortcuts-overlay.visible { display: flex; }
+#ide-shortcuts-box {
+    background: #252526; border: 1px solid #454545; color: #ccc;
+    width: min(720px, 100%); max-height: 85vh; overflow: auto;
+    border-radius: 6px; box-shadow: 4px 8px 24px rgba(0,0,0,0.7);
+}
+body[data-theme="light"] #ide-shortcuts-box { background: #fff; color: #222; border-color: #b8b8b8; }
+body[data-theme="hc"] #ide-shortcuts-box { background: #000; color: #fff; border: 2px solid #ffd700; }
+#ide-shortcuts-header {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 12px 16px; border-bottom: 1px solid #454545;
+    font-size: 14px; font-weight: 600;
+}
+body[data-theme="light"] #ide-shortcuts-header { border-bottom-color: #ddd; }
+#ide-shortcuts-close {
+    background: none; border: none; color: inherit; cursor: pointer;
+    font-size: 18px; line-height: 1; padding: 4px 8px; border-radius: 3px;
+}
+#ide-shortcuts-close:hover { background: rgba(255,255,255,0.1); }
+#ide-shortcuts-body { padding: 12px 16px 16px; }
+.shortcut-section { margin-bottom: 14px; }
+.shortcut-section h4 {
+    margin: 4px 0 6px; font-size: 11px; text-transform: uppercase;
+    letter-spacing: 1px; color: #9cdcfe;
+}
+body[data-theme="light"] .shortcut-section h4 { color: #006bb3; }
+.shortcut-row {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 4px 0; font-size: 13px;
+    border-bottom: 1px dashed rgba(255,255,255,0.06);
+}
+body[data-theme="light"] .shortcut-row { border-bottom-color: rgba(0,0,0,0.06); }
+.shortcut-keys { display: flex; gap: 4px; }
+.shortcut-keys kbd {
+    background: #3c3c3c; color: #fff;
+    border: 1px solid #555; border-bottom-width: 2px;
+    border-radius: 3px; padding: 1px 6px;
+    font-family: 'Consolas', monospace; font-size: 12px;
+}
+body[data-theme="light"] .shortcut-keys kbd { background: #f5f5f5; color: #222; border-color: #b8b8b8; }
+body[data-theme="hc"] .shortcut-keys kbd { background: #000; color: #ffd700; border: 1px solid #ffd700; }
+
+/* ============================================================
+   RESPONSIVE / COMPACT LAYOUT — narrow screens (~phones / Chromebook portrait)
+   The IDE wasn't designed for phones, but students often READ the exercise on
+   their phone. Below ~900px we hide the activity bar (it's reachable from menus),
+   collapse the sidebar by default, and stack the bottom panel under the editor.
+   ============================================================ */
+@media (max-width: 900px) {
+    body { font-size: 12px; }
+    #ide-titlebar { height: auto; min-height: 30px; flex-wrap: wrap; }
+    #ide-menubar { flex-wrap: wrap; }
+    .menu-item { padding: 0 8px; font-size: 12px; }
+    .menu-shortcut { display: none; }
+    #ide-title-center { display: none; }
+    #ide-activity-bar { display: none; }
+    #ide-sidebar { width: 200px; min-width: 60px; max-width: 80vw; }
+    #ide-sidebar.compact-hidden { display: none; }
+    #sidebar-resize-handle { display: none; }
+    .action-btn { padding: 3px 6px; font-size: 11px; }
+    #ide-bottom-panel { height: 200px; }
+    .bottom-tab { padding: 0 8px; font-size: 10px; }
+}
+@media (max-width: 600px) {
+    .menu-item { padding: 0 6px; }
+    #ide-status-bar { font-size: 10px; }
+    #status-wordwrap { display: none; }
+    #ide-bottom-panel { height: 35vh; }
+}
 
 </style>
 
@@ -552,6 +1069,22 @@ button:focus, input:focus, select:focus, .tab:focus {
           <div class="menu-dropdown-item" role="menuitem" tabindex="-1" id="menu-wordwrap-item" onclick="menuToggleWordWrap()">Word Wrap <span class="menu-shortcut" aria-label="Alt Z">Alt+Z</span></div>
           <hr role="separator">
           <div class="menu-dropdown-item" role="menuitem" tabindex="-1" onclick="menuShowInfo()">Exercise Info</div>
+          <hr role="separator">
+          <!-- Preferences (theme / font / reading mode) -->
+          <div class="menu-dropdown-item" role="menuitem" tabindex="-1" onclick="menuCycleTheme()">
+            Theme: <span id="menu-theme-label" class="menu-value">Dark</span>
+          </div>
+          <div class="menu-dropdown-item" role="menuitem" tabindex="-1" onclick="menuCycleFontSize()">
+            Font Size: <span id="menu-fontsize-label" class="menu-value">14px</span>
+          </div>
+          <div class="menu-dropdown-item" role="menuitem" tabindex="-1" onclick="menuToggleReadingMode()">
+            Reading Mode: <span id="menu-readingmode-label" class="menu-value">Default</span>
+          </div>
+          <div class="menu-dropdown-item" role="menuitem" tabindex="-1" onclick="menuToggleColorblind()">
+            Color-Blind Mode: <span id="menu-colorblind-label" class="menu-value">Off</span>
+          </div>
+          <hr role="separator">
+          <div class="menu-dropdown-item" role="menuitem" tabindex="-1" onclick="if(typeof menuShowRunHistory==='function')menuShowRunHistory()">Run History…</div>
         </div>
       </div>
 
@@ -565,7 +1098,23 @@ button:focus, input:focus, select:focus, .tab:focus {
           <div class="menu-dropdown-item" role="menuitem" tabindex="-1" onclick="document.getElementById('run').click()">Run Code <span class="menu-shortcut" aria-label="Ctrl Enter">Ctrl+Enter</span></div>
           <div class="menu-dropdown-item" role="menuitem" tabindex="-1" onclick="menuSaveAndRun()">Save &amp; Run <span class="menu-shortcut" aria-label="F5">F5</span></div>
           <hr role="separator">
+          <div class="menu-dropdown-item" role="menuitem" tabindex="-1" onclick="window.toggleBreakpointAtCursor()">Toggle Breakpoint <span class="menu-shortcut" aria-label="F9">F9</span></div>
+          <div class="menu-dropdown-item" role="menuitem" tabindex="-1" onclick="window.clearAllBreakpoints()">Clear All Breakpoints</div>
+          <hr role="separator">
+          <div class="menu-dropdown-item" role="menuitem" tabindex="-1" onclick="if(typeof runAllTests==='function')runAllTests()">Run Tests <span class="menu-shortcut" aria-label="Alt T">Alt+T</span></div>
+          <hr role="separator">
           <div class="menu-dropdown-item" role="menuitem" tabindex="-1" onclick="menuClearOutput()">Clear Output</div>
+        </div>
+      </div>
+
+      <!-- Help menu -->
+      <div class="menu-item" id="menu-help"
+           role="menuitem" tabindex="-1"
+           aria-haspopup="true" aria-expanded="false"
+           aria-label="Help menu">
+        Help
+        <div class="menu-dropdown" role="menu" aria-label="Help">
+          <div class="menu-dropdown-item" role="menuitem" tabindex="-1" onclick="menuShowShortcuts()">Keyboard Shortcuts <span class="menu-shortcut" aria-label="question mark">?</span></div>
         </div>
       </div>
 
@@ -735,6 +1284,13 @@ button:focus, input:focus, select:focus, .tab:focus {
           {{ page.info.instructions }}
           <hr class="info-divider">
           {% endif %}
+
+          <!-- Hint ladder — populated by JS as the student accrues failed runs.
+               Lives in the info panel so it stays visible while they work. -->
+          <div id="hint-ladder" hidden>
+            <h3>Hints</h3>
+            <div id="hint-ladder-list" style="font-size:11px;"></div>
+          </div>
           {{ content }}
           <hr class="info-divider" style="margin-top:16px;">
           <p style="font-size:10px; color:#a0a0a0; margin:8px 0 0;">
@@ -809,6 +1365,12 @@ button:focus, input:focus, select:focus, .tab:focus {
           <button class="bottom-tab"        id="btab-suggestions"
                   role="tab" aria-selected="false" aria-controls="suggestions-panel" tabindex="-1"
                   onclick="switchBottomTab('suggestions')">Suggestions <span id="suggestions-count" aria-label="suggestion count" style="opacity:0.6;"></span></button>
+          <button class="bottom-tab"        id="btab-inspector"
+                  role="tab" aria-selected="false" aria-controls="inspector-panel" tabindex="-1"
+                  onclick="switchBottomTab('inspector')">Inspector</button>
+          <button class="bottom-tab"        id="btab-tests"
+                  role="tab" aria-selected="false" aria-controls="tests-panel" tabindex="-1"
+                  onclick="switchBottomTab('tests')">Tests <span id="tests-count" aria-label="test count" style="opacity:0.6;"></span></button>
 
           <div id="bottom-panel-actions">
             <button class="icon-btn" id="clear-console" title="Clear Output" aria-label="Clear output">✕ Clear Output</button>
@@ -830,6 +1392,102 @@ button:focus, input:focus, select:focus, .tab:focus {
           <div id="suggestions-list" aria-live="polite" aria-atomic="false">
             <div style="padding:20px; text-align:center; color:#a0a0a0;">
               No suggestions. Code quality feedback will appear here.
+            </div>
+          </div>
+        </div>
+
+        <!-- Tests Panel: student-runnable per-exercise tests -->
+        <div id="tests-panel" class="bottom-content" role="tabpanel" aria-labelledby="btab-tests" hidden>
+          <div id="tests-toolbar" style="display:flex; gap:6px; padding:4px 8px; border-bottom:1px solid #2d2d2d; background:#252526;">
+            <button id="tests-run-all" class="action-btn" type="button"
+                    style="padding:2px 10px; height:22px; font-size:11px;">▶ Run Tests</button>
+            <span id="tests-summary" style="font-size:11px; opacity:0.7; align-self:center;"></span>
+          </div>
+          <div id="tests-body" style="flex:1; overflow:auto; padding:6px 8px;"
+               role="status" aria-live="polite" aria-atomic="false">
+            <div class="tests-empty" style="text-align:center; color:#a0a0a0; padding:20px;">
+              No tests for this exercise. Instructors can add tests in the page front-matter under
+              <code>processor.tests:</code>.
+            </div>
+          </div>
+        </div>
+
+        <!-- Inspector Panel: variables, step-through (Python), call-stack tape -->
+        <div id="inspector-panel" class="bottom-content" role="tabpanel" aria-labelledby="btab-inspector" hidden>
+          <div id="inspector-toolbar" role="tablist" aria-label="Inspector views">
+            <button class="inspector-subtab active" id="insub-vars"
+                    role="tab" aria-selected="true" aria-controls="inspector-vars"
+                    onclick="switchInspectorView('vars')">Variables</button>
+            <button class="inspector-subtab" id="insub-steps"
+                    role="tab" aria-selected="false" aria-controls="inspector-steps" tabindex="-1"
+                    onclick="switchInspectorView('steps')">Step-Through</button>
+            <button class="inspector-subtab" id="insub-trace"
+                    role="tab" aria-selected="false" aria-controls="inspector-trace" tabindex="-1"
+                    onclick="switchInspectorView('trace')">Call Tape</button>
+            <button class="inspector-subtab" id="insub-profile"
+                    role="tab" aria-selected="false" aria-controls="inspector-profile" tabindex="-1"
+                    onclick="switchInspectorView('profile')">Profile</button>
+            <button class="inspector-subtab" id="insub-visualize"
+                    role="tab" aria-selected="false" aria-controls="inspector-visualize" tabindex="-1"
+                    onclick="switchInspectorView('visualize')">Visualize</button>
+            <div style="margin-left:auto; display:flex; gap:6px; padding:0 6px;">
+              <button id="inspector-step-run" class="action-btn" type="button"
+                      title="Re-run with step instrumentation (Python only)"
+                      style="padding:2px 10px; height:22px; font-size:11px;">↻ Step Run</button>
+            </div>
+          </div>
+          <div id="inspector-body">
+            <div id="inspector-vars" class="inspector-view active" role="tabpanel" aria-labelledby="insub-vars">
+              <div class="inspector-empty">Run your code to inspect variables.</div>
+            </div>
+            <div id="inspector-steps" class="inspector-view" role="tabpanel" aria-labelledby="insub-steps" hidden>
+              <div class="inspector-empty">Click <strong>Step Run</strong> above to record execution steps. Available for Python.</div>
+            </div>
+            <div id="inspector-profile" class="inspector-view" role="tabpanel" aria-labelledby="insub-profile" hidden>
+              <div class="inspector-empty">Run your code to see a profile. Pyodide records timing automatically; JavaScript uses <code class="code-inline">webideTrace.call()</code> / <code class="code-inline">webideTrace.return()</code>.</div>
+            </div>
+            <div id="inspector-visualize" class="inspector-view" role="tabpanel" aria-labelledby="insub-visualize" hidden>
+              <div class="inspector-empty">Step through your code to visualize the heap. Variables containing lists, dicts, or objects are rendered as graphs.</div>
+            </div>
+            <div id="inspector-trace" class="inspector-view" role="tabpanel" aria-labelledby="insub-trace" hidden>
+              <div class="inspector-empty" style="text-align:left; max-width:720px; margin:0 auto;">
+                <p style="text-align:center; margin:0 0 10px;"><strong>Run your code to see the function-call tape.</strong></p>
+                <p>For <strong>Python</strong>, calls are recorded automatically (use <strong>Step Run</strong>
+                on the Inspector toolbar).</p>
+                <p>For <strong>JavaScript</strong> or <strong>Java (Processing)</strong>, you have to record
+                the markers yourself. These helpers are <strong>labels</strong> — they don't call any function,
+                they only annotate this tape.</p>
+
+                <p><strong>Option 1 — sibling log (simple).</strong> Call
+                <code class="code-inline">webideTrace.tap('name', arg1, arg2)</code> once per event.
+                Each <code class="code-inline">tap</code> shows up as a flat sibling. Use this when you just
+                want to know "did this code run?" or "in what order did these run?".</p>
+
+                <p><strong>Option 2 — scope tracking (for nested / recursive calls).</strong>
+                Put <code class="code-inline">webideTrace.call('name', args…)</code> as the
+                <strong>first line inside the function body</strong>, and
+                <code class="code-inline">webideTrace.return(value)</code> immediately
+                <strong>before every return statement</strong> (or once at the end if the function is void).
+                Then call the function normally from outside.</p>
+
+                <pre class="webide-code-block">// JavaScript example
+function fact(n) {
+    <strong>webideTrace.call('fact', n);</strong>          // at the top
+    if (n &lt;= 1) {
+        return <strong>webideTrace.return(1)</strong>;     // wrap every return
+    }
+    let r = n * fact(n - 1);
+    return <strong>webideTrace.return(r)</strong>;
+}
+fact(4);   // now the tape shows fact(4) → fact(3) → fact(2) → fact(1)</pre>
+
+                <p style="font-size:11px; opacity:0.75;">
+                Every <code class="code-inline">call</code> must be matched by a <code class="code-inline">return</code>.
+                If you put three <code class="code-inline">call</code>s in a row without
+                <code class="code-inline">return</code>s, each one ends up nested inside the previous (which
+                is what the IDE will warn about with <em>"no .return"</em>). For that case use
+                <code class="code-inline">tap</code> instead.</p>
+              </div>
             </div>
           </div>
         </div>
@@ -886,6 +1544,83 @@ button:focus, input:focus, select:focus, .tab:focus {
   </div>
 </div>
 
+<!-- Keyboard shortcuts overlay (opened via "?" key or Help > Keyboard Shortcuts) -->
+<!-- Run history modal -->
+<div id="run-history-dialog" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="run-history-title">
+  <div class="webide-modal-box">
+    <div style="display:flex; align-items:center; justify-content:space-between; padding:12px 16px; border-bottom:1px solid #454545;">
+      <span id="run-history-title" style="font-weight:600;">Run history</span>
+      <button type="button" onclick="document.getElementById('run-history-dialog').classList.remove('visible');"
+              style="background:none; border:none; color:inherit; cursor:pointer; font-size:18px;">✕</button>
+    </div>
+    <div id="run-history-list" style="padding:8px 0;"></div>
+    <div style="padding:8px 16px; opacity:0.6; font-size:11px;">
+      Up to 20 most recent runs are kept per exercise. "Restore" opens the snapshot in a new read-only tab so your current work isn't overwritten.
+    </div>
+  </div>
+</div>
+
+<!-- Submission preflight modal -->
+<div id="preflight-dialog" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="preflight-title">
+  <div class="webide-modal-box">
+    <div style="display:flex; align-items:center; justify-content:space-between; padding:12px 16px; border-bottom:1px solid #454545;">
+      <span id="preflight-title" style="font-weight:600;">Before you submit…</span>
+    </div>
+    <div id="preflight-body" style="padding:16px;"></div>
+    <div style="display:flex; gap:8px; padding:8px 16px; justify-content:flex-end; border-top:1px solid #454545;">
+      <button id="preflight-cancel" class="form-btn" type="button">Fix and review</button>
+      <button id="preflight-submit" class="form-btn" type="button">Submit anyway</button>
+    </div>
+  </div>
+</div>
+
+<div id="ide-shortcuts-overlay"
+     role="dialog"
+     aria-modal="true"
+     aria-labelledby="ide-shortcuts-title"
+     aria-hidden="true">
+  <div id="ide-shortcuts-box">
+    <div id="ide-shortcuts-header">
+      <span id="ide-shortcuts-title">Keyboard Shortcuts</span>
+      <button id="ide-shortcuts-close" aria-label="Close shortcuts dialog">✕</button>
+    </div>
+    <div id="ide-shortcuts-body">
+      <div class="shortcut-section">
+        <h4>Editing &amp; Files</h4>
+        <div class="shortcut-row"><span>Save current file</span><span class="shortcut-keys"><kbd>Ctrl</kbd><kbd>S</kbd></span></div>
+        <div class="shortcut-row"><span>Run code</span><span class="shortcut-keys"><kbd>Ctrl</kbd><kbd>Enter</kbd></span></div>
+        <div class="shortcut-row"><span>Save and Run</span><span class="shortcut-keys"><kbd>F5</kbd></span></div>
+        <div class="shortcut-row"><span>Toggle breakpoint on current line</span><span class="shortcut-keys"><kbd>F9</kbd></span></div>
+        <div class="shortcut-row"><span>Run Tests panel</span><span class="shortcut-keys"><kbd>Alt</kbd><kbd>T</kbd></span></div>
+        <div class="shortcut-row"><span>Toggle word wrap</span><span class="shortcut-keys"><kbd>Alt</kbd><kbd>Z</kbd></span></div>
+      </div>
+      <div class="shortcut-section">
+        <h4>View</h4>
+        <div class="shortcut-row"><span>Toggle sidebar</span><span class="shortcut-keys"><kbd>Ctrl</kbd><kbd>B</kbd></span></div>
+        <div class="shortcut-row"><span>Toggle terminal panel</span><span class="shortcut-keys"><kbd>Ctrl</kbd><kbd>`</kbd></span></div>
+        <div class="shortcut-row"><span>Focus Explorer</span><span class="shortcut-keys"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>E</kbd></span></div>
+        <div class="shortcut-row"><span>Focus Terminal tab</span><span class="shortcut-keys"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>T</kbd></span></div>
+        <div class="shortcut-row"><span>Focus Output tab</span><span class="shortcut-keys"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>O</kbd></span></div>
+        <div class="shortcut-row"><span>Focus Suggestions tab</span><span class="shortcut-keys"><kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>P</kbd></span></div>
+      </div>
+      <div class="shortcut-section">
+        <h4>Editor Font</h4>
+        <div class="shortcut-row"><span>Increase font size</span><span class="shortcut-keys"><kbd>Ctrl</kbd><kbd>=</kbd></span></div>
+        <div class="shortcut-row"><span>Decrease font size</span><span class="shortcut-keys"><kbd>Ctrl</kbd><kbd>-</kbd></span></div>
+      </div>
+      <div class="shortcut-section">
+        <h4>Help</h4>
+        <div class="shortcut-row"><span>Show this dialog</span><span class="shortcut-keys"><kbd>?</kbd></span></div>
+        <div class="shortcut-row"><span>Close any dialog</span><span class="shortcut-keys"><kbd>Esc</kbd></span></div>
+      </div>
+      <p style="font-size:11px; opacity:0.7; margin-top:8px;">
+        Tip: Within an input field, "?" types a literal question mark. Press <kbd>Esc</kbd> first
+        to leave the field, then press <kbd>?</kbd> to open this dialog.
+      </p>
+    </div>
+  </div>
+</div>
+
 {% if page.language == "pyodide" %}
 <div id="pyodideBoilerplate" style="display:none;">
 import io, base64
@@ -909,6 +1644,168 @@ def pyodide_print(s):
     global PYODIDE_COUT
     PYODIDE_COUT += s
 
+</div>
+
+<!-- Step-through tracer for Pyodide (full CPython, so sys.settrace works
+     completely). Prepended to user code when Step Run is requested. -->
+<div id="pyodideStepPrologue" style="display:none;">
+import sys as _webide_sys
+_webide_steps = []
+_webide_calltree = {'name': '&lt;module&gt;', 'args': '', 'children': [], 'returnValue': None, 'exception': None, 'lineno': 0}
+_webide_call_stack = [_webide_calltree]
+_webide_STEP_LIMIT = 2000
+_webide_CALL_LIMIT = 2000
+_webide_call_count = [0]
+
+def _webide_safe_repr(v, limit=80):
+    try:
+        if isinstance(v, (int, float, bool)) or v is None: return str(v)
+        if isinstance(v, str):
+            s = v if len(v) &lt; limit else v[:limit] + '...'
+            return repr(s)
+        if callable(v): return '&lt;function ' + getattr(v, '__name__', '?') + '&gt;'
+        s = repr(v)
+        return s if len(s) &lt; limit else s[:limit] + '...'
+    except Exception:
+        return '&lt;unrepresentable&gt;'
+
+import time as _webide_time
+
+def _webide_tracer(frame, event, arg):
+    try:
+        # Pyodide's pyodide.runPython is itself implemented in Python — it
+        # parses, compiles, and AST-walks the student source via eval_code /
+        # generate_tokens / deepcopy / iter_fields / etc. Without a filter,
+        # settrace records all of THAT internal machinery and the tape fills
+        # with hundreds of iter_child_nodes/_make/deepcopy frames before the
+        # student code ever runs. The runPython call site tags student
+        # source with a unique co_filename ('&lt;webide-student&gt;') so we can
+        # accept ONLY those frames here and skip everything else (returning
+        # None from a global trace function tells CPython not to install a
+        # local tracer for that frame, but child frames still pass through
+        # this global tracer — so we filter each one independently).
+        co_fname = frame.f_code.co_filename or ''
+        if co_fname != '&lt;webide-student&gt;':
+            return None
+        fname = frame.f_code.co_name
+        lineno = frame.f_lineno
+        if event == 'line' and len(_webide_steps) &lt; _webide_STEP_LIMIT:
+            locs = {}
+            for k, v in frame.f_locals.items():
+                if k.startswith('_webide') or k.startswith('__'): continue
+                locs[k] = {'type': type(v).__name__, 'value': _webide_safe_repr(v)}
+            _webide_steps.append({'lineno': lineno, 'function': fname, 'locals': locs})
+        elif event == 'call' and _webide_call_count[0] &lt; _webide_CALL_LIMIT:
+            _webide_call_count[0] += 1
+            args = []
+            try:
+                for k, v in frame.f_locals.items():
+                    if k.startswith('__'): continue
+                    args.append(k + '=' + _webide_safe_repr(v, 40))
+            except Exception:
+                pass
+            node = {'name': fname, 'args': ', '.join(args[:6]), 'children': [],
+                    'returnValue': None, 'exception': None, 'lineno': lineno,
+                    't_start': _webide_time.monotonic(), 'duration_ms': 0}
+            _webide_call_stack[-1]['children'].append(node)
+            _webide_call_stack.append(node)
+        elif event == 'return':
+            if len(_webide_call_stack) &gt; 1:
+                _webide_call_stack[-1]['returnValue'] = _webide_safe_repr(arg)
+                try:
+                    _webide_call_stack[-1]['duration_ms'] = \
+                        (_webide_time.monotonic() - _webide_call_stack[-1].get('t_start', 0)) * 1000.0
+                except Exception:
+                    pass
+                _webide_call_stack.pop()
+        elif event == 'exception':
+            if len(_webide_call_stack) &gt; 0:
+                try:
+                    _webide_call_stack[-1]['exception'] = _webide_safe_repr(
+                        arg[1] if isinstance(arg, tuple) else arg)
+                except Exception:
+                    _webide_call_stack[-1]['exception'] = '&lt;exception&gt;'
+    except Exception:
+        pass
+    return _webide_tracer
+
+# NOTE: settrace is NOT installed here. The JS-side step runner sets
+# _webide_student_source and runs pyodideStepExec, which installs settrace
+# only around the student code — preventing Pyodide's eval_code / compile /
+# AST machinery from being recorded as part of the call tape.
+</div>
+
+<!-- Wrapper that actually runs the student source under settrace. The
+     JS side calls pyodide.globals.set('_webide_student_source', code)
+     before invoking this. The explicit compile() lets us tag student
+     frames with a unique co_filename. -->
+<div id="pyodideStepExec" style="display:none;">
+_webide_compiled = compile(_webide_student_source, '&lt;webide-student&gt;', 'exec')
+_webide_sys.settrace(_webide_tracer)
+try:
+    exec(_webide_compiled, globals())
+finally:
+    _webide_sys.settrace(None)
+del _webide_compiled, _webide_student_source
+</div>
+
+<div id="pyodideStepEpilogue" style="display:none;">
+# kept for backwards compat with any callers that still invoke it
+_webide_sys.settrace(None)
+</div>
+
+<!-- Breakpoints-only tracer for Pyodide. Records ONLY the lines listed in
+     _webide_bp_lines (a Python set). Used when the student clicks Run with
+     gutter breakpoints set, but did NOT click Step Run. Recording every
+     line is too noisy for routine debugging. -->
+<div id="pyodideBpPrologue" style="display:none;">
+import sys as _webide_sys
+_webide_bp_steps = []
+_webide_bp_lines = set()
+_webide_BP_LIMIT = 2000
+
+def _webide_bp_safe_repr(v, limit=80):
+    try:
+        if isinstance(v, (int, float, bool)) or v is None: return str(v)
+        if isinstance(v, str):
+            s = v if len(v) &lt; limit else v[:limit] + '...'
+            return repr(s)
+        if callable(v): return '&lt;function ' + getattr(v, '__name__', '?') + '&gt;'
+        s = repr(v)
+        return s if len(s) &lt; limit else s[:limit] + '...'
+    except Exception:
+        return '&lt;unrepresentable&gt;'
+
+def _webide_bp_tracer(frame, event, arg):
+    try:
+        co_fname = frame.f_code.co_filename or ''
+        if co_fname != '&lt;webide-student&gt;':
+            return None
+        if event == 'line' and frame.f_lineno in _webide_bp_lines \
+                and len(_webide_bp_steps) &lt; _webide_BP_LIMIT:
+            locs = {}
+            for k, v in frame.f_locals.items():
+                if k.startswith('_webide') or k.startswith('__'): continue
+                locs[k] = {'type': type(v).__name__, 'value': _webide_bp_safe_repr(v)}
+            _webide_bp_steps.append({
+                'lineno': frame.f_lineno,
+                'function': frame.f_code.co_name,
+                'locals': locs,
+                'hit': True,
+            })
+    except Exception:
+        pass
+    return _webide_bp_tracer
+</div>
+
+<div id="pyodideBpExec" style="display:none;">
+_webide_compiled = compile(_webide_student_source, '&lt;webide-student&gt;', 'exec')
+_webide_sys.settrace(_webide_bp_tracer)
+try:
+    exec(_webide_compiled, globals())
+finally:
+    _webide_sys.settrace(None)
+del _webide_compiled, _webide_student_source
 </div>
 {% endif %}
 
@@ -935,18 +1832,248 @@ def pyodide_print(s):
                 ret += sep
         return ret + end
 
-    def run_python_code(code):
-        result = ""
+    # ---------- Inspector helpers (variables + call tape + step-through) -----
+    # These mirror state into JS globals (window['__webide_vars'] etc.) where
+    # the IDE renders them in the Inspector panel after each run.
+
+    _WEBIDE_RESERVED = {'window', 'get_formatted', '__name__', '__builtins__'}
+
+    def _webide_safe_repr(v, limit=200):
+        try:
+            if isinstance(v, (int, float, bool)) or v is None:
+                return str(v)
+            if isinstance(v, str):
+                return v if len(v) < limit else v[:limit] + '...'
+            if callable(v):
+                return '<function ' + getattr(v, '__name__', '?') + '>'
+            s = repr(v)
+            return s if len(s) < limit else s[:limit] + '...'
+        except Exception:
+            return '<unrepresentable>'
+
+    def _webide_snapshot_vars(ns):
+        snap = {}
+        for k, v in ns.items():
+            if k in _WEBIDE_RESERVED:
+                continue
+            if k.startswith('__') and k.endswith('__'):
+                continue
+            tname = type(v).__name__
+            snap[k] = {'type': tname, 'value': _webide_safe_repr(v)}
+        return snap
+
+    def _webide_dict_to_js(d):
+        # Convert a Python dict to a JS-side plain object, recursively for one level.
+        obj = window.Object.new()
+        for k, v in d.items():
+            if isinstance(v, dict):
+                inner = window.Object.new()
+                for ik, iv in v.items():
+                    inner[ik] = iv
+                obj[k] = inner
+            else:
+                obj[k] = v
+        return obj
+
+    def _webide_list_to_js(lst):
+        arr = window.Array.new()
+        for item in lst:
+            if isinstance(item, dict):
+                arr.push(_webide_dict_to_js(item))
+            else:
+                arr.push(item)
+        return arr
+
+    # Postlude appended to user code so we can snapshot top-level user names
+    # from the same scope they're assigned in. (Brython's `from browser import
+    # window` doesn't survive being passed via exec's explicit ns dict, so we
+    # use the default exec(code) behavior and inject the snapshot inline.)
+    # All function-local names in the runner are prefixed `_webide_` so we can
+    # filter them out reliably here.
+    _WEBIDE_VAR_POSTLUDE = (
+        "\n\n"
+        "try:\n"
+        "    window['__webide_vars'] = window.Object.new()\n"
+        "    for _wk in list(locals().keys()):\n"
+        "        if _wk.startswith('_webide') or _wk.startswith('__'): continue\n"
+        "        if _wk in ('window','get_formatted','traceback','sys','doc','tb','_WEBIDE_VAR_POSTLUDE',\n"
+        "                   '_WEBIDE_RESERVED','_STEP_LIMIT','_CALL_LIMIT'): continue\n"
+        "        _wv = locals()[_wk]\n"
+        "        try: _ws = repr(_wv)\n"
+        "        except Exception: _ws = '<unrepresentable>'\n"
+        "        if len(_ws) > 200: _ws = _ws[:200] + '...'\n"
+        "        _wo = window.Object.new()\n"
+        "        _wo['type'] = type(_wv).__name__\n"
+        "        _wo['value'] = _ws\n"
+        "        window['__webide_vars'][_wk] = _wo\n"
+        "except Exception as _werr:\n"
+        "    pass\n"
+    )
+
+    # Brython trace-on-hit helper. Mirrors the JS `__webide_bp` helper but
+    # lets the injected Python statement record a hit. We expose the
+    # generated locals() to the JS helper so the Inspector populates with
+    # real Python values, not just line numbers.
+    def __webide_bp_py(_lineno, _locals):
+        try:
+            cleaned = window.Object.new()
+            for _k in _locals:
+                if _k.startswith('_webide') or _k.startswith('__'): continue
+                _v = _locals[_k]
+                _t = type(_v).__name__
+                try:
+                    _s = repr(_v)
+                except Exception:
+                    _s = '<unrepresentable>'
+                if len(_s) > 200: _s = _s[:200] + '...'
+                _wo = window.Object.new()
+                _wo['type']  = _t
+                _wo['value'] = _s
+                cleaned[_k]  = _wo
+            window['__webide_bp'](_lineno, cleaned)
+        except Exception:
+            pass
+    window['__webide_bp_py'] = __webide_bp_py
+
+    def run_python_code(_webide_code):
+        _webide_result = ""
         try:
             window['python_code_result'] = ''
-            code = code.replace("print(", "window['python_code_result'] += get_formatted(")
-            exec(code)
-            result = window['python_code_result']
-        except Exception as exc:
-            result = traceback.format_exc()
-        return result
+            # Trace-on-hit instrumentation: inject __webide_bp_py(...) lines.
+            try:
+                _bp_lines = window['__webide_activeBreakpointLines']()
+                _bp_arr = []
+                # Brython lists from JS Arrays need explicit conversion.
+                try:
+                    for _i in range(_bp_lines.length):
+                        _bp_arr.append(int(_bp_lines[_i]))
+                except Exception:
+                    pass
+                if _bp_arr:
+                    _webide_code = window['webideInstrumentForBreakpoints'](
+                        _webide_code, 'python', _bp_arr)
+            except Exception:
+                pass
+            _webide_code = _webide_code.replace("print(", "window['python_code_result'] += get_formatted(")
+            _webide_code = _webide_code + _WEBIDE_VAR_POSTLUDE
+            exec(_webide_code)
+            _webide_result = window['python_code_result']
+        except Exception as _webide_exc:
+            _webide_result = traceback.format_exc()
+        return _webide_result
+
+    # ---------- Step-through + call tape via sys.settrace --------------------
+    # Brython's settrace support is limited and may not fire for all events,
+    # but Pyodide (full CPython) handles it cleanly. The JS side checks the
+    # resulting arrays and shows a graceful fallback message if empty.
+
+    _STEP_LIMIT = 2000   # cap to avoid runaway captures
+    _CALL_LIMIT = 2000
+
+    def run_python_code_traced(_webide_code):
+        steps = []
+        call_root = {'name': '<module>', 'args': '', 'children': [], 'returnValue': None, 'exception': None}
+        call_stack = [call_root]
+        call_count = [0]
+
+        def tracer(frame, event, arg):
+            try:
+                fname = frame.f_code.co_name
+                lineno = frame.f_lineno
+                if event == 'line' and len(steps) < _STEP_LIMIT:
+                    locs = {}
+                    for k, v in frame.f_locals.items():
+                        if k in _WEBIDE_RESERVED: continue
+                        if k.startswith('__'): continue
+                        locs[k] = {'type': type(v).__name__, 'value': _webide_safe_repr(v, 80)}
+                    steps.append({
+                        'lineno': lineno,
+                        'function': fname,
+                        'locals': locs,
+                    })
+                elif event == 'call' and call_count[0] < _CALL_LIMIT:
+                    call_count[0] += 1
+                    args = []
+                    try:
+                        for k, v in frame.f_locals.items():
+                            if k.startswith('__'): continue
+                            args.append(k + '=' + _webide_safe_repr(v, 40))
+                    except Exception:
+                        pass
+                    node = {
+                        'name': fname,
+                        'args': ', '.join(args[:6]),
+                        'children': [],
+                        'returnValue': None,
+                        'exception': None,
+                        'lineno': lineno,
+                    }
+                    call_stack[-1]['children'].append(node)
+                    call_stack.append(node)
+                elif event == 'return':
+                    if len(call_stack) > 1:
+                        call_stack[-1]['returnValue'] = _webide_safe_repr(arg, 80)
+                        call_stack.pop()
+                elif event == 'exception':
+                    if len(call_stack) > 0:
+                        try:
+                            call_stack[-1]['exception'] = _webide_safe_repr(arg[1] if isinstance(arg, tuple) else arg, 80)
+                        except Exception:
+                            call_stack[-1]['exception'] = '<exception>'
+            except Exception:
+                pass
+            return tracer
+
+        _webide_result = ""
+        try:
+            window['python_code_result'] = ''
+            _webide_traced = _webide_code.replace("print(", "window['python_code_result'] += get_formatted(")
+            _webide_traced = _webide_traced + _WEBIDE_VAR_POSTLUDE
+            sys.settrace(tracer)
+            try:
+                exec(_webide_traced)
+            finally:
+                sys.settrace(None)
+            _webide_result = window['python_code_result']
+        except Exception as _webide_exc:
+            _webide_result = traceback.format_exc()
+
+        # Convert nested Python dicts/lists to JS-friendly objects/arrays.
+        def to_js(node):
+            o = window.Object.new()
+            o['name'] = node['name']
+            o['args'] = node['args']
+            o['returnValue'] = node['returnValue']
+            o['exception'] = node['exception']
+            o['lineno'] = node.get('lineno', 0)
+            kids = window.Array.new()
+            for c in node['children']:
+                kids.push(to_js(c))
+            o['children'] = kids
+            return o
+
+        try:
+            steps_js = window.Array.new()
+            for s in steps:
+                obj = window.Object.new()
+                obj['lineno'] = s['lineno']
+                obj['function'] = s['function']
+                inner = window.Object.new()
+                for k, v in s['locals'].items():
+                    cell = window.Object.new()
+                    cell['type'] = v['type']
+                    cell['value'] = v['value']
+                    inner[k] = cell
+                obj['locals'] = inner
+                steps_js.push(obj)
+            window['__webide_steps'] = steps_js
+            window['__webide_calltree'] = to_js(call_root)
+        except Exception:
+            pass
+        return _webide_result
 
     window.run_python_code = run_python_code
+    window.run_python_code_traced = run_python_code_traced
 </script>
 
 <!-- xterm.js (terminal emulator) -->
@@ -1036,15 +2163,198 @@ def pyodide_print(s):
         };
 
         // -- Console output ----------------------------------------------------
+        // Plain-English explanations for common errors across the languages this
+        // IDE supports. Patterns are matched in order; the first match wins.
+        // Keep entries terse — the goal is to nudge a stuck student, not to
+        // replace the official docs.
+        const WEBIDE_ERROR_DICT = [
+            // ---- Python (Brython + Pyodide) ----
+            { lang: 'python', re: /NameError: name '([^']+)' is not defined/,
+              explain: (m) => `Python doesn't recognize "${m[1]}". Either you misspelled it, you forgot to define it before using it, or you forgot to import it (e.g. \`import math\`).` },
+            { lang: 'python', re: /IndentationError: (.*)/,
+              explain: (m) => `Python is strict about indentation. ${m[1]}. Make sure each block (after \`if\`, \`for\`, \`def\`, etc.) is indented by the same number of spaces — most editors use 4.` },
+            { lang: 'python', re: /TabError/,
+              explain: () => `You mixed tabs and spaces for indentation. Pick one and stick with it — most Python style guides recommend 4 spaces.` },
+            { lang: 'python', re: /TypeError: ([^(]+) takes (\d+) positional argument/,
+              explain: (m) => `You're calling \`${m[1].trim()}\` with the wrong number of arguments. It expects ${m[2]}.` },
+            { lang: 'python', re: /TypeError: unsupported operand type\(s\) for ([^:]+): '([^']+)' and '([^']+)'/,
+              explain: (m) => `You tried to use \`${m[1].trim()}\` between a ${m[2]} and a ${m[3]}. Convert one of them first — for example \`int("5")\` or \`str(5)\`.` },
+            { lang: 'python', re: /IndexError: list index out of range/,
+              explain: () => `You asked for an item beyond the end of a list. Lists are 0-indexed: a list of length 5 has valid indices 0..4. Print \`len(your_list)\` to check.` },
+            { lang: 'python', re: /KeyError: '?([^'"]+)'?/,
+              // The captured key is unquoted in the exception message; the
+              // suggested code needs it quoted, otherwise it reads as a bare
+              // identifier (NameError when run).
+              explain: (m) => `The dictionary doesn't have a key called \`'${m[1]}'\`. Check the spelling, or use \`my_dict.get('${m[1]}')\` to get \`None\` instead of an error when the key is missing.` },
+            { lang: 'python', re: /ZeroDivisionError/,
+              explain: () => `You divided by zero. Add a check like \`if denominator != 0:\` before the division.` },
+            { lang: 'python', re: /SyntaxError: (.*)/,
+              explain: (m) => `Python can't parse your code. ${m[1]}. The error usually points one character AFTER the real problem — check for a missing \`)\`, \`:\`, or quote on the previous line.` },
+            { lang: 'python', re: /AttributeError: '([^']+)' object has no attribute '([^']+)'/,
+              explain: (m) => `A ${m[1]} doesn't have a method or property called \`${m[2]}\`. Did you mean a different method? Use \`dir(your_object)\` to see what's available.` },
+            { lang: 'python', re: /RecursionError|maximum recursion depth/,
+              explain: () => `Your function called itself too many times without reaching a base case. Make sure your recursion has an \`if\` that returns without recursing.` },
+            // ---- JavaScript ----
+            { lang: 'javascript', re: /(?:Reference|ReferenceError):? ([^ ]+) is not defined/,
+              explain: (m) => `JavaScript doesn't recognize "${m[1]}". Either you misspelled it or you forgot to declare it with \`let\`, \`const\`, or \`var\`.` },
+            { lang: 'javascript', re: /TypeError: Cannot read propert(?:y|ies) of (undefined|null) \(reading '([^']+)'\)/,
+              explain: (m) => `You tried to read \`.${m[2]}\` on a value that is ${m[1]}. Check that the object exists before using it — e.g. \`if (obj && obj.${m[2]})\`.` },
+            { lang: 'javascript', re: /TypeError: ([^ ]+) is not a function/,
+              explain: (m) => `\`${m[1]}\` is not a function. Either it's the wrong type (maybe an object or undefined), or you misspelled the function name.` },
+            { lang: 'javascript', re: /SyntaxError: (.*)/,
+              explain: (m) => `JavaScript can't parse your code. ${m[1]}. Check for a missing \`}\`, \`)\`, or \`;\`. The error often points one line AFTER the real problem.` },
+            { lang: 'javascript', re: /Maximum call stack size exceeded/,
+              explain: () => `Your function called itself too many times. Make sure recursive functions have a base case that returns without recursing.` },
+            // ---- Java (Processing) ----
+            { lang: 'java', re: /NullPointerException/,
+              explain: () => `You tried to use an object that hasn't been created yet (it's \`null\`). Make sure you call \`new Something()\` and assigned it to your variable before using it.` },
+            { lang: 'java', re: /ArrayIndexOutOfBoundsException:?\s*(-?\d+)?/,
+              explain: (m) => `You asked for index ${m[1] || '?'} of an array, but that's outside the valid range. Java arrays are 0-indexed: \`arr[0]\` to \`arr[arr.length - 1]\`.` },
+            { lang: 'java', re: /cannot find symbol[\s\S]*?symbol:\s*(.+)/,
+              explain: (m) => `The compiler doesn't recognize \`${m[1].trim()}\`. Check spelling, capitalization, and that you've declared it (or imported its class).` },
+            { lang: 'java', re: /\bclass [A-Z]\w* is public, should be declared in a file/,
+              explain: () => `In Java the public class must match the file name. Either rename the class or rename the file.` },
+            { lang: 'java', re: /incompatible types/,
+              explain: () => `You're assigning a value of one type to a variable of another. Java requires explicit conversion — e.g. \`Integer.parseInt("5")\` or \`(int) 3.7\`.` },
+            // ---- C / C++ ----
+            { lang: 'cpp', re: /segmentation fault|SIGSEGV/i,
+              explain: () => `Your program tried to access memory it doesn't own. Common causes: dereferencing a null/uninitialized pointer, going past the end of an array, or recursing too deep.` },
+            { lang: 'cpp', re: /undefined reference to '([^']+)'/,
+              explain: (m) => `The linker can't find \`${m[1]}\`. Did you spell it the same way it was declared? If it's from a library, you may need to include the right header or compile its .cpp file.` },
+            { lang: 'cpp', re: /'([^']+)' was not declared in this scope/,
+              explain: (m) => `\`${m[1]}\` isn't visible at the point where you used it. Either you misspelled it, you forgot to include the header that declares it, or you defined it inside a different function or namespace.` },
+            { lang: 'cpp', re: /expected '([^']+)' before '([^']+)'/,
+              explain: (m) => `The compiler expected \`${m[1]}\` before \`${m[2]}\`. Often you missed a \`;\` or \`)\` on the previous line.` },
+            // ---- SQL ----
+            { lang: 'sql', re: /no such (table|column): (\w+)/i,
+              explain: (m) => `SQL doesn't see a ${m[1]} called \`${m[2]}\`. Check the spelling and the schema — column and table names are case-sensitive in some setups.` },
+            { lang: 'sql', re: /syntax error/i,
+              explain: () => `SQL can't parse your query. Common causes: missing comma between columns, missing quotes around strings, unmatched parentheses, or a reserved word used as an identifier.` },
+            // ---- Scheme ----
+            { lang: 'scheme', re: /Unbound variable: (\S+)/i,
+              explain: (m) => `Scheme doesn't recognize \`${m[1]}\`. Either you misspelled it, or you forgot to \`define\` it before using it.` },
+            { lang: 'scheme', re: /Wrong number of arguments/i,
+              explain: () => `You called a procedure with the wrong number of arguments. Check the procedure's definition for how many parameters it expects.` },
+            { lang: 'scheme', re: /not a (number|pair|procedure)/i,
+              explain: (m) => `Scheme expected a ${m[1]} but got something else. Add a \`(display ...)\` to inspect the actual value.` },
+            // ---- Prolog ----
+            { lang: 'prolog', re: /procedure (\S+) does not exist/i,
+              explain: (m) => `Prolog doesn't have a predicate \`${m[1]}\` defined. Check the spelling and arity — \`foo/2\` is a different predicate than \`foo/3\`.` },
+            { lang: 'prolog', re: /Syntax error/i,
+              explain: () => `Prolog can't parse your code. Make sure each clause ends with a period (\`.\`), variables start with capital letters, and atoms start with lowercase letters.` },
+            // ---- Generic catch-alls (last-resort) ----
+            { lang: '*', re: /Permission denied/,
+              explain: () => `The browser blocked something — usually localStorage being full, IndexedDB locked by another tab, or a CORS issue. Try closing other browser tabs of this exercise.` },
+            { lang: '*', re: /Failed to fetch/,
+              explain: () => `A network request failed. Check your internet connection. If you're offline, the exercise should still work for everything except submission.` },
+        ];
+
+        const _PAGE_LANG = '{{ page.language | default: "" }}';
+        window._PAGE_LANG = _PAGE_LANG;  // tests panel + future helpers read this
+        const _LANG_FAMILY = (() => {
+            // Map page.language to dictionary 'lang' codes
+            if (_PAGE_LANG === 'python' || _PAGE_LANG === 'pyodide') return 'python';
+            if (_PAGE_LANG === 'cpp') return 'cpp';
+            if (_PAGE_LANG === 'java' || _PAGE_LANG === 'graphics_view' || _PAGE_LANG === 'graphics_shader') return 'java';
+            if (_PAGE_LANG === 'javascript') return 'javascript';
+            if (_PAGE_LANG === 'sql') return 'sql';
+            if (_PAGE_LANG === 'scheme') return 'scheme';
+            if (_PAGE_LANG === 'prolog') return 'prolog';
+            return '*';
+        })();
+
+        function findErrorExplanation(message) {
+            // Try language-specific patterns first, then generic ones.
+            const ordered = WEBIDE_ERROR_DICT
+                .filter(e => e.lang === _LANG_FAMILY)
+                .concat(WEBIDE_ERROR_DICT.filter(e => e.lang === '*'));
+            for (const entry of ordered) {
+                const m = message.match(entry.re);
+                if (m) {
+                    try { return entry.explain(m); }
+                    catch (e) { return null; }
+                }
+            }
+            return null;
+        }
+
+        // Heuristic: does this output line look like an error / traceback / exception?
+        // Note: many Python error class names embed "Error" without a word
+        // boundary (IndentationError, RecursionError, AttributeError, etc.)
+        // so the regex deliberately does NOT use \b around "Error".
+        function looksLikeError(message) {
+            if (!message) return false;
+            return /(?:Error|Exception|Traceback|undefined reference|segmentation fault|SIGSEGV|cannot find symbol|no such (?:table|column)|Unbound variable|procedure .* does not exist|Wrong number of arguments)/i.test(message);
+        }
+
         function logToConsole(message) {
             const newLine = document.createElement('div');
             newLine.textContent = message + '\n';
+            // For likely error lines, attach an inline "What does this mean?" affordance
+            // that expands a plain-English explanation drawn from WEBIDE_ERROR_DICT.
+            if (looksLikeError(String(message))) {
+                const explanation = findErrorExplanation(String(message));
+                if (explanation) {
+                    newLine.style.borderLeft = '3px solid #f48771';
+                    newLine.style.paddingLeft = '6px';
+                    newLine.style.margin = '4px 0';
+                    const btn = document.createElement('button');
+                    btn.type = 'button';
+                    btn.textContent = '? What does this mean?';
+                    btn.className = 'webide-explain-btn';
+                    btn.setAttribute('aria-expanded', 'false');
+                    btn.style.cssText = 'display:inline-block; margin-left:8px; margin-top:2px; padding:1px 8px; background:#3a3a3a; color:#9cdcfe; border:1px solid #555; border-radius:3px; cursor:pointer; font-size:11px; font-family:inherit;';
+                    const expl = document.createElement('div');
+                    expl.className = 'webide-explain-body';
+                    expl.style.cssText = 'display:none; margin:4px 0 4px 6px; padding:6px 8px; background:#1e1e1e; border-left:3px solid #75beff; color:#cccccc; font-size:12px; line-height:1.5; white-space:normal;';
+                    expl.textContent = explanation;
+                    btn.addEventListener('click', () => {
+                        const open = expl.style.display !== 'none';
+                        expl.style.display = open ? 'none' : 'block';
+                        btn.setAttribute('aria-expanded', open ? 'false' : 'true');
+                        btn.textContent = open ? '? What does this mean?' : '✕ Hide explanation';
+                    });
+                    newLine.appendChild(btn);
+                    newLine.appendChild(expl);
+                    // Also surface in the Suggestions tab for discoverability
+                    try { addExplanationToSuggestions(String(message), explanation); } catch (e) {}
+                }
+            }
             consoleOutput.appendChild(newLine);
             newLine.scrollIntoView({ behavior: "smooth" });
             // If terminal panel is not active, auto-switch to output
             switchBottomTab('output');
         }
 
+        // Mirror error explanations into the existing Suggestions panel so
+        // students who closed the output without reading it can still find help.
+        function addExplanationToSuggestions(errorLine, explanation) {
+            const list = document.getElementById('suggestions-list');
+            if (!list) return;
+            // Clear placeholder text on first real entry
+            const placeholder = list.querySelector('div[style*="text-align"]');
+            if (placeholder) placeholder.remove();
+            const item = document.createElement('button');
+            item.type = 'button';
+            item.className = 'suggestion-item error';
+            item.innerHTML = `
+                <span class="suggestion-icon" aria-hidden="true">!</span>
+                <span class="suggestion-content">
+                  <span class="suggestion-message"></span>
+                  <span class="suggestion-hint"></span>
+                </span>`;
+            item.querySelector('.suggestion-message').textContent = errorLine.split('\n')[0].slice(0, 200);
+            item.querySelector('.suggestion-hint').textContent = explanation;
+            list.appendChild(item);
+            // Update count badge
+            const count = list.querySelectorAll('.suggestion-item').length;
+            const badge = document.getElementById('suggestions-count');
+            if (badge) badge.textContent = count > 0 ? '(' + count + ')' : '';
+        }
+
+        // Expose logToConsole on window so other scripts (and the browser
+        // console) can write into the IDE output the same way the runtime does.
+        window.logToConsole = logToConsole;
         logToConsole("Console output...");
 
         // -- Processing / Java boilerplate -------------------------------------
@@ -1290,6 +2600,12 @@ def pyodide_print(s):
             saveBtn.disabled = openFiles[path].readOnly;
             setTabAceProperties(path);
             ace_editor.resize();
+            // Re-apply any breakpoints stored for this file. The session is
+            // shared across tabs but its breakpoint set isn't, so we sync on
+            // every tab switch.
+            if (typeof _applyBreakpointsToSession === 'function') {
+                _applyBreakpointsToSession(path, ace_editor.session);
+            }
             // Trigger static analysis immediately when a file is displayed
             _triggerAnalysis();
         }
@@ -2261,6 +3577,205 @@ def pyodide_print(s):
         // Initialize accessibility features
         setupAccessibilityShortcuts();
 
+        // Render hint ladder on load (no-op when there are no hints).
+        setTimeout(() => { try { _renderHintLadder(); } catch (e) {} }, 0);
+
+        // -- Register offline service worker --------------------------------
+        // Cache-first for the IDE shell, network-first for language runtime
+        // bundles. Lives at site root; jekyll copies it as-is.
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register('{{site.baseurl}}/service-worker.js', { scope: '{{site.baseurl}}/' })
+                    .then(reg => { window.__webide_sw_registered = true; })
+                    .catch(err => { console.warn('Service worker registration failed:', err); });
+            });
+        }
+
+        // -- Wire the Tests panel after the helpers are defined ------------
+        // _initTestsPanel + runAllTests live further down the file (next to
+        // checkAnswer); the DOM is ready by the time this runs, and the
+        // helpers will be hoisted into scope because they're function
+        // declarations. We use setTimeout(...,0) so the button binding
+        // happens after the second pass over the script.
+        setTimeout(() => {
+            try {
+                if (typeof _initTestsPanel === 'function') _initTestsPanel();
+                const btn = document.getElementById('tests-run-all');
+                if (btn) btn.addEventListener('click', () => {
+                    if (typeof runAllTests === 'function') runAllTests();
+                });
+            } catch (e) { console.warn('tests panel init failed', e); }
+        }, 0);
+
+        // -- Preferences (theme, font size, reading mode) ---------------------
+        // Persisted in localStorage under 'webide.prefs' as a JSON object.
+        // Applied to <body> via data-attributes that CSS selectors target.
+        const PREFS_KEY = 'webide.prefs';
+        const PREFS_DEFAULTS = { theme: 'dark', fontSize: 14, readingMode: 'default', colorblind: false };
+        const THEMES = ['dark', 'light', 'hc'];
+        const THEME_LABELS = { dark: 'Dark', light: 'Light', hc: 'High Contrast' };
+        const FONT_STEPS = [11, 12, 13, 14, 16, 18, 20, 24];
+        const READING_MODES = ['default', 'dyslexia'];
+        const READING_LABELS = { default: 'Default', dyslexia: 'Dyslexia-Friendly' };
+
+        function loadPrefs() {
+            try {
+                const raw = localStorage.getItem(PREFS_KEY);
+                if (!raw) return { ...PREFS_DEFAULTS };
+                return { ...PREFS_DEFAULTS, ...JSON.parse(raw) };
+            } catch (e) {
+                return { ...PREFS_DEFAULTS };
+            }
+        }
+        function savePrefs(p) {
+            try { localStorage.setItem(PREFS_KEY, JSON.stringify(p)); }
+            catch (e) { /* localStorage may be full or disabled — silently ignore */ }
+        }
+
+        let _prefs = loadPrefs();
+
+        function applyPrefs() {
+            // Theme — sets body[data-theme]; CSS rules handle the visuals.
+            const theme = THEMES.includes(_prefs.theme) ? _prefs.theme : 'dark';
+            document.body.dataset.theme = theme;
+            // ACE theme: keep monokai for dark (existing default), use CSS
+            // overrides for light/hc so we don't need to ship extra theme files.
+            if (ace_editor) {
+                ace_editor.setTheme('ace/theme/monokai');
+                ace_editor.setFontSize(_prefs.fontSize);
+                // Force re-render so token classes pick up new colors
+                try { ace_editor.renderer.updateText(); } catch (e) {}
+            }
+            // Apply font size to any other ace instances that exist (file tabs etc.)
+            document.querySelectorAll('.ace_editor').forEach(el => {
+                try {
+                    const ed = ace.edit(el);
+                    ed.setFontSize(_prefs.fontSize);
+                } catch (e) {}
+            });
+            // Reading mode (dyslexia)
+            const mode = READING_MODES.includes(_prefs.readingMode) ? _prefs.readingMode : 'default';
+            document.body.dataset.readingmode = mode;
+            // Color-blind mode — separate from high-contrast theme; tweaks
+            // semantic colors (pass/fail/error) so the meaning carries
+            // through without depending solely on hue.
+            if (_prefs.colorblind) document.body.dataset.colorblind = 'true';
+            else                   delete document.body.dataset.colorblind;
+            // Sync menu labels
+            const tLab = document.getElementById('menu-theme-label');
+            const fLab = document.getElementById('menu-fontsize-label');
+            const rLab = document.getElementById('menu-readingmode-label');
+            const cLab = document.getElementById('menu-colorblind-label');
+            if (tLab) tLab.textContent = THEME_LABELS[theme] || 'Dark';
+            if (fLab) fLab.textContent = _prefs.fontSize + 'px';
+            if (rLab) rLab.textContent = READING_LABELS[mode] || 'Default';
+            if (cLab) cLab.textContent = _prefs.colorblind ? 'On' : 'Off';
+        }
+
+        window.menuCycleTheme = () => {
+            const idx = THEMES.indexOf(_prefs.theme);
+            _prefs.theme = THEMES[(idx + 1) % THEMES.length];
+            savePrefs(_prefs); applyPrefs();
+            if (typeof ideNotify === 'function') ideNotify('Theme: ' + THEME_LABELS[_prefs.theme]);
+        };
+        window.menuCycleFontSize = () => {
+            const cur = parseInt(_prefs.fontSize, 10) || 14;
+            const next = FONT_STEPS.find(s => s > cur) || FONT_STEPS[0];
+            _prefs.fontSize = next;
+            savePrefs(_prefs); applyPrefs();
+            if (typeof ideNotify === 'function') ideNotify('Font size: ' + next + 'px');
+        };
+        window.menuToggleReadingMode = () => {
+            const idx = READING_MODES.indexOf(_prefs.readingMode);
+            _prefs.readingMode = READING_MODES[(idx + 1) % READING_MODES.length];
+            savePrefs(_prefs); applyPrefs();
+            if (typeof ideNotify === 'function') ideNotify('Reading mode: ' + READING_LABELS[_prefs.readingMode]);
+        };
+        window.menuToggleColorblind = () => {
+            _prefs.colorblind = !_prefs.colorblind;
+            savePrefs(_prefs); applyPrefs();
+            if (typeof ideNotify === 'function') ideNotify('Color-blind mode: ' + (_prefs.colorblind ? 'On' : 'Off'));
+        };
+
+        // Ensure any later editor created via ace.edit() also picks up font size
+        // and any future theme change (the existing Ctrl+= / Ctrl+- handlers
+        // already mutate setFontSize directly; we also persist the change).
+        document.addEventListener('keydown', (e) => {
+            if ((e.ctrlKey || e.metaKey) && (e.key === '=' || e.key === '+')) {
+                const cur = parseInt(_prefs.fontSize, 10) || 14;
+                _prefs.fontSize = Math.min(40, cur + 1);
+                savePrefs(_prefs);
+            } else if ((e.ctrlKey || e.metaKey) && e.key === '-') {
+                const cur = parseInt(_prefs.fontSize, 10) || 14;
+                _prefs.fontSize = Math.max(8, cur - 1);
+                savePrefs(_prefs);
+            }
+        });
+
+        // Apply on load — also re-applies once ace_editor is created later
+        // (loadPrefsAndApply is called again after ace.edit("editor-container")).
+        applyPrefs();
+        window.__webideApplyPrefs = applyPrefs;  // exposed so ace init can call it
+
+        // -- Keyboard shortcut overlay ---------------------------------------
+        let _shortcutsPreviousFocus = null;
+        function isTypingTarget(el) {
+            if (!el) return false;
+            const tag = el.tagName;
+            if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+            if (el.isContentEditable) return true;
+            // ACE renders into a div with a hidden textarea; treat .ace_text-input as typing target
+            if (el.classList && el.classList.contains('ace_text-input')) return true;
+            return false;
+        }
+        window.menuShowShortcuts = () => {
+            const dialog = document.getElementById('ide-shortcuts-overlay');
+            const closeBtn = document.getElementById('ide-shortcuts-close');
+            if (!dialog) return;
+            _shortcutsPreviousFocus = document.activeElement;
+            dialog.classList.add('visible');
+            dialog.setAttribute('aria-hidden', 'false');
+            setTimeout(() => closeBtn && closeBtn.focus(), 30);
+
+            const focusableSelectors = 'a[href], button:not([disabled]), input, [tabindex]:not([tabindex="-1"])';
+            const trapFocus = e => {
+                if (e.key !== 'Tab') return;
+                const focusable = Array.from(dialog.querySelectorAll(focusableSelectors));
+                if (!focusable.length) { e.preventDefault(); return; }
+                const first = focusable[0], last = focusable[focusable.length - 1];
+                if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+                else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+            };
+            const close = () => {
+                dialog.classList.remove('visible');
+                dialog.setAttribute('aria-hidden', 'true');
+                dialog.removeEventListener('keydown', trapFocus);
+                dialog.removeEventListener('keydown', escHandler);
+                if (closeBtn) closeBtn.removeEventListener('click', close);
+                dialog.removeEventListener('click', backdropClose);
+                if (_shortcutsPreviousFocus && _shortcutsPreviousFocus.focus) {
+                    try { _shortcutsPreviousFocus.focus(); } catch (e) {}
+                }
+            };
+            const escHandler = e => { if (e.key === 'Escape') { e.preventDefault(); close(); } };
+            const backdropClose = e => { if (e.target === dialog) close(); };
+            dialog.addEventListener('keydown', trapFocus);
+            dialog.addEventListener('keydown', escHandler);
+            if (closeBtn) closeBtn.addEventListener('click', close);
+            dialog.addEventListener('click', backdropClose);
+        };
+
+        // "?" opens the shortcut overlay — unless the user is typing in a field.
+        // Shift+/ is the same key on US keyboards; both events fire e.key === '?'.
+        document.addEventListener('keydown', e => {
+            if (e.key !== '?') return;
+            if (isTypingTarget(e.target)) return;
+            // Don't trigger when modifier keys other than Shift are held
+            if (e.ctrlKey || e.altKey || e.metaKey) return;
+            e.preventDefault();
+            window.menuShowShortcuts();
+        });
+
         // -- Enhanced Terminal Commands (Proposals 3, 4) ----------------------
         // These integrate with the existing handleCommand function
         // Added: gdb, pdb, pytest, unittest commands for debugging and testing
@@ -2303,13 +3818,959 @@ def pyodide_print(s):
         });
 
         let _runGuard = false;
+
+        // -- Infinite-loop watchdog ------------------------------------------
+        // Many student programs accidentally enter an infinite loop. Most
+        // languages here run on the main thread (Brython exec, JS eval,
+        // Processing.js), so we cannot truly KILL the loop without the user
+        // reloading. But we can warn them that something is wrong instead of
+        // letting the tab look frozen with no explanation.
+        const RUN_WATCHDOG_SOFT_MS  = 5000;   // first warning
+        const RUN_WATCHDOG_HARD_MS  = 15000;  // strong warning + reload prompt
+        let _runWatchdogTimers = [];
+        let _runningBanner = null;
+        function clearRunWatchdog() {
+            _runWatchdogTimers.forEach(t => clearTimeout(t));
+            _runWatchdogTimers = [];
+            if (_runningBanner) { _runningBanner.remove(); _runningBanner = null; }
+        }
+        function startRunWatchdog() {
+            clearRunWatchdog();
+            // Immediate visible banner — works even if the runtime synchronously
+            // freezes the main thread. The banner is removed once runCode settles.
+            try {
+                _runningBanner = document.createElement('div');
+                _runningBanner.style.cssText = 'border-left:3px solid #75beff; padding:6px 8px; margin:6px 0; background:#1a2733; color:#9cdcfe; font-size:12px;';
+                _runningBanner.innerHTML = '<strong>▶ Running…</strong> If the page freezes for more than ~10 seconds, your code may have an infinite loop. Your file work is saved automatically — refresh the tab (Ctrl/Cmd+R) to recover.';
+                consoleOutput.appendChild(_runningBanner);
+                _runningBanner.scrollIntoView({ behavior: 'smooth' });
+            } catch (e) {}
+            const softT = setTimeout(() => {
+                if (typeof ideNotify === 'function') {
+                    ideNotify('Code is still running after 5 seconds. If your tab feels frozen it may be an infinite loop — your work is auto-saved, you can refresh to recover.', 'error');
+                }
+                // "Show me where I'm stuck" affordance — append a button to the
+                // running banner that jumps the editor to the last-traced
+                // line. Works whenever the runtime has populated
+                // __webide_steps (Pyodide tracer, JS instrumentation, etc.).
+                try {
+                    if (_runningBanner && !_runningBanner.querySelector('.webide-stuck-btn')) {
+                        const btn = document.createElement('button');
+                        btn.type = 'button';
+                        btn.className = 'webide-stuck-btn';
+                        btn.textContent = 'Show me where';
+                        btn.style.cssText = 'margin-left:8px; padding:2px 10px; background:#75beff; color:#000; border:none; border-radius:3px; cursor:pointer; font-size:11px;';
+                        btn.addEventListener('click', () => {
+                            const steps = (window.__webide_steps || []);
+                            const last  = steps.length ? steps[steps.length - 1] : null;
+                            if (!last) {
+                                ideNotify('No traced steps yet — try setting a breakpoint (F9) on a suspect line.', 'info');
+                                return;
+                            }
+                            if (window.ace_editor) {
+                                window.ace_editor.gotoLine(last.lineno, 0, true);
+                                window.ace_editor.focus();
+                            }
+                            switchBottomTab('inspector');
+                            try { switchInspectorView('steps'); } catch (e) {}
+                        });
+                        _runningBanner.appendChild(btn);
+                    }
+                } catch (e) {}
+            }, RUN_WATCHDOG_SOFT_MS);
+            const hardT = setTimeout(() => {
+                // After the hard threshold, also write a permanent message into
+                // the console so the warning is visible after the toast fades.
+                try {
+                    const div = document.createElement('div');
+                    div.style.cssText = 'border-left:3px solid #f48771; padding:6px 8px; margin:6px 0; background:#2d1f1f; color:#f48771;';
+                    div.innerHTML = '<strong>⚠ Infinite loop suspected.</strong> Code has been running for 15+ seconds. ';
+                    const reloadBtn = document.createElement('button');
+                    reloadBtn.type = 'button';
+                    reloadBtn.textContent = 'Reload page';
+                    reloadBtn.style.cssText = 'margin-left:8px; padding:2px 10px; background:#f48771; color:#000; border:none; border-radius:3px; cursor:pointer; font-size:11px;';
+                    reloadBtn.addEventListener('click', () => location.reload());
+                    div.appendChild(reloadBtn);
+                    consoleOutput.appendChild(div);
+                    div.scrollIntoView({ behavior: 'smooth' });
+                    switchBottomTab('output');
+                } catch (e) {}
+            }, RUN_WATCHDOG_HARD_MS);
+            _runWatchdogTimers.push(softT, hardT);
+        }
+
         runBtn.addEventListener('click', () => {
             if (_runGuard) return;
             _runGuard = true;
             setTimeout(() => { _runGuard = false; }, 1000);
             saveActiveTabs();
-            runCode();  // runCode handles compile-if-needed, logging, and tab switching
+            startRunWatchdog();
+            _beforeRun();
+            // runCode is async; clear the watchdog when it settles, success or fail.
+            // Wrapped in Promise.resolve so non-Promise return values don't crash.
+            Promise.resolve()
+                .then(() => runCode())
+                .finally(() => { clearRunWatchdog(); _afterRun(); });
         });
+
+        // -- Inspector (variables, step-through, call tape) --------------------
+        // Populated after each run from window.__webide_vars / __webide_steps /
+        // __webide_calltree (Python) or by diffing window keys (JavaScript) plus
+        // the optional window.webideTrace API students can call from JS code.
+        const _inspectorState = {
+            vars: null,        // { name: { type, value }, ... }
+            steps: null,       // [ { lineno, function, locals } ]
+            callTree: null,    // root call node
+            currentStep: 0,
+            hasRun: false,     // flipped to true the first time _afterRun fires
+            _lineMarkerId: null,
+        };
+        let _stepRunRequested = false;
+
+        // -- Breakpoints ------------------------------------------------------
+        // Persisted in localStorage under 'webide.breakpoints' as
+        //   { "<filepath>": [lineno, lineno, ...] }
+        // Lines are 1-based to match what students see in the gutter.
+        // The in-memory _breakpoints mirror is what the runtime queries.
+        const BREAKPOINTS_KEY = 'webide.breakpoints';
+        let _breakpoints = (() => {
+            try {
+                const raw = localStorage.getItem(BREAKPOINTS_KEY);
+                return raw ? JSON.parse(raw) : {};
+            } catch (e) { return {}; }
+        })();
+        function _saveBreakpoints() {
+            try { localStorage.setItem(BREAKPOINTS_KEY, JSON.stringify(_breakpoints)); }
+            catch (e) { /* quota — silently drop */ }
+        }
+        function _getActivePath() {
+            const t = document.querySelector('.tab.active');
+            return (t && t.id && t.id !== SUBMIT_TAB_ID) ? t.id : null;
+        }
+        function getBreakpointsForPath(path) {
+            if (!path) return [];
+            return (_breakpoints[path] || []).slice();
+        }
+        // Exposed so the runtime hooks (Pyodide tracer, source-instrumenter)
+        // can ask "is line N of file P a breakpoint?" and so tests can drive
+        // the toggle without depending on cursor position.
+        window.webideBreakpoints = {
+            get: (path) => getBreakpointsForPath(path),
+            getForActive: () => getBreakpointsForPath(_getActivePath()),
+            has: (path, line) => (_breakpoints[path] || []).includes(line),
+            toggle: (path, line) => toggleBreakpoint(path, line),
+        };
+
+        function _applyBreakpointsToSession(path, session) {
+            if (!session) return;
+            session.clearBreakpoints();
+            for (const ln of getBreakpointsForPath(path)) {
+                // Ace rows are 0-based; we store 1-based to match the gutter.
+                session.setBreakpoint(ln - 1, 'webide-breakpoint');
+            }
+        }
+
+        function toggleBreakpoint(path, line) {
+            if (!path) return;
+            const arr = _breakpoints[path] || [];
+            const i = arr.indexOf(line);
+            if (i >= 0) arr.splice(i, 1);
+            else        arr.push(line);
+            if (arr.length === 0) delete _breakpoints[path];
+            else { arr.sort((a, b) => a - b); _breakpoints[path] = arr; }
+            _saveBreakpoints();
+            if (path === _getActivePath() && typeof ace_editor !== 'undefined' && ace_editor) {
+                _applyBreakpointsToSession(path, ace_editor.session);
+            }
+        }
+
+        function clearAllBreakpoints(path) {
+            if (path === undefined) {
+                _breakpoints = {};
+                _saveBreakpoints();
+                if (typeof ace_editor !== 'undefined' && ace_editor) {
+                    ace_editor.session.clearBreakpoints();
+                }
+                if (typeof ideNotify === 'function') ideNotify('Cleared all breakpoints');
+            } else {
+                delete _breakpoints[path];
+                _saveBreakpoints();
+                if (path === _getActivePath() && typeof ace_editor !== 'undefined' && ace_editor) {
+                    ace_editor.session.clearBreakpoints();
+                }
+            }
+        }
+        window.clearAllBreakpoints = clearAllBreakpoints;
+
+        // -- Trace-on-hit runtime helpers ------------------------------------
+        // For languages without a native debugger (JS, Java/Processing, Scheme,
+        // Prolog, SQL, C/C++), we source-instrument the student code before
+        // executing it: at every breakpoint line we inject a call to
+        // `__webide_bp(line, locals)`. The helper records the hit into
+        // `window.__webide_steps` and (for Pyodide-flavor) `__webide_calltree`,
+        // so the existing Inspector "Step-Through" and "Variables" sub-tabs
+        // populate identically to the Python settrace path. No real pause.
+        window.__webide_bp = function(line, locals) {
+            try {
+                if (!window.__webide_steps) window.__webide_steps = [];
+                if (window.__webide_steps.length >= 2000) return;
+                const cleaned = {};
+                if (locals && typeof locals === 'object') {
+                    for (const k of Object.keys(locals)) {
+                        const v = locals[k];
+                        let type, value;
+                        try {
+                            if (v === null)               { type = 'null';  value = 'null'; }
+                            else if (Array.isArray(v))    { type = 'array'; value = JSON.stringify(v).slice(0, 200); }
+                            else if (typeof v === 'function') { type = 'function'; value = '<function ' + (v.name || '?') + '>'; }
+                            else if (typeof v === 'object') { type = 'object'; value = JSON.stringify(v).slice(0, 200); }
+                            else                           { type = typeof v; value = String(v).slice(0, 200); }
+                        } catch (e) { type = '?'; value = '<unrepresentable>'; }
+                        cleaned[k] = { type, value };
+                    }
+                }
+                window.__webide_steps.push({
+                    lineno: line, function: '<bp>', locals: cleaned, hit: true,
+                });
+                // Brief console breadcrumb so students see the breakpoint fire
+                // even before they look at the Inspector.
+                if (typeof logToConsole === 'function') {
+                    const summary = Object.keys(cleaned).slice(0, 6)
+                        .map(k => k + '=' + cleaned[k].value).join(', ');
+                    logToConsole('[bp line ' + line + ']' + (summary ? '  ' + summary : ''));
+                }
+            } catch (e) { /* never throw out of the hit handler */ }
+        };
+
+        // Returns the path-keyed breakpoint set for the active file, or [] if
+        // there's no active file. Runtime hooks call this to know which lines
+        // to instrument before running.
+        window.__webide_activeBreakpointLines = function() {
+            const path = _getActivePath();
+            if (!path) return [];
+            return getBreakpointsForPath(path);
+        };
+
+        // -- Source instrumentation -----------------------------------------
+        // Insert `__webide_bp(<line>, {...locals})` calls at each breakpoint
+        // line of the given source. `lang` selects how to write the call:
+        //   - 'js' / 'java' / 'graphics' — `__webide_bp(L, {a:typeof a!=='undefined'?a:undefined});`
+        //   - 'scheme'                  — `(begin (webide-bp L) ...)`   (sibling call)
+        //   - 'sql'                     — leading comment marker (parsed runtime-side)
+        //   - 'prolog'                  — `webide_bp(L), ...`
+        //   - 'cpp'                     — `printf("__BP %d\n", L);`
+        //   - 'python'                  — `__webide_bp_py(L, vars())`   (Brython only)
+        //
+        // For JS-family languages, we additionally try to capture obvious
+        // top-level identifier values via a lightweight regex scan of the
+        // student source. We deliberately avoid AST parsing — false positives
+        // are safe (typeof-guarded), false negatives are recoverable.
+        function _webideExtractTopIdents(src) {
+            const re = /\b(?:let|const|var|function)\s+([A-Za-z_$][\w$]*)/g;
+            const names = new Set();
+            let m; while ((m = re.exec(src))) names.add(m[1]);
+            return [...names];
+        }
+        function _webideJsLocalsExpr(idents) {
+            if (!idents.length) return '{}';
+            // try/catch handles both undeclared globals and let/const TDZ — a
+            // plain `typeof` reads OK for `var` but throws inside a let's
+            // temporal dead zone.
+            return '{' + idents.map(n =>
+                JSON.stringify(n) + ': (function(){try{return ' + n + ';}catch(_){return undefined;}})()'
+            ).join(', ') + '}';
+        }
+
+        window.webideInstrumentForBreakpoints = function(src, lang, bpLines) {
+            if (!bpLines || !bpLines.length) return src;
+            const set = new Set(bpLines.map(n => +n));
+            const lines = src.split('\n');
+            const out = new Array(lines.length);
+            if (lang === 'js' || lang === 'java' || lang === 'graphics' || lang === 'javascript') {
+                const localsExpr = _webideJsLocalsExpr(_webideExtractTopIdents(src));
+                for (let i = 0; i < lines.length; i++) {
+                    const lineNo = i + 1;
+                    if (set.has(lineNo)) {
+                        // Prepend the trap call. We keep it on its own line so
+                        // student error line numbers remain unchanged for the
+                        // post-trap statements.
+                        out[i] = '__webide_bp(' + lineNo + ', ' + localsExpr + '); ' + lines[i];
+                    } else {
+                        out[i] = lines[i];
+                    }
+                }
+            } else if (lang === 'scheme') {
+                for (let i = 0; i < lines.length; i++) {
+                    const lineNo = i + 1;
+                    if (set.has(lineNo)) out[i] = '(webide-bp ' + lineNo + ') ' + lines[i];
+                    else out[i] = lines[i];
+                }
+            } else if (lang === 'prolog') {
+                // Prolog can't easily host a side-effect call mid-clause without
+                // changing semantics; emit a marker comment that the runtime
+                // surfaces as "(breakpoint at line N: planned hit)".
+                for (let i = 0; i < lines.length; i++) {
+                    const lineNo = i + 1;
+                    if (set.has(lineNo)) out[i] = '% __BP ' + lineNo + '\n' + lines[i];
+                    else out[i] = lines[i];
+                }
+            } else if (lang === 'sql') {
+                // sql.js executes statement-by-statement; we just tag the
+                // statement so the JS-side runner emits a hit after running it.
+                for (let i = 0; i < lines.length; i++) {
+                    const lineNo = i + 1;
+                    if (set.has(lineNo)) out[i] = '-- __BP ' + lineNo + '\n' + lines[i];
+                    else out[i] = lines[i];
+                }
+            } else if (lang === 'cpp' || lang === 'c') {
+                // Plain printf marker; the runtime worker parses stdout for these.
+                for (let i = 0; i < lines.length; i++) {
+                    const lineNo = i + 1;
+                    if (set.has(lineNo)) out[i] = 'printf("__BP %d\\n", ' + lineNo + '); ' + lines[i];
+                    else out[i] = lines[i];
+                }
+            } else if (lang === 'python' || lang === 'brython') {
+                for (let i = 0; i < lines.length; i++) {
+                    const lineNo = i + 1;
+                    if (set.has(lineNo)) {
+                        const indent = (lines[i].match(/^\s*/) || [''])[0];
+                        // Insert the trap on its OWN line, ahead of the student
+                        // line — preserves indentation so we don't break blocks.
+                        out[i] = indent + '__webide_bp_py(' + lineNo + ', vars())\n' + lines[i];
+                    } else {
+                        out[i] = lines[i];
+                    }
+                }
+            } else {
+                return src;
+            }
+            return out.join('\n');
+        };
+
+        // F9 toggles a breakpoint on the cursor line.
+        window.toggleBreakpointAtCursor = () => {
+            if (typeof ace_editor === 'undefined' || !ace_editor) return;
+            const path = _getActivePath();
+            if (!path) {
+                if (typeof ideNotify === 'function') ideNotify('Open a file first to set a breakpoint', 'error');
+                return;
+            }
+            const row  = ace_editor.getCursorPosition().row;  // 0-based
+            const line = row + 1;
+            toggleBreakpoint(path, line);
+            if (typeof ideNotify === 'function') {
+                const has = window.webideBreakpoints.has(path, line);
+                ideNotify((has ? 'Breakpoint set' : 'Breakpoint removed') + ' on line ' + line);
+            }
+        };
+
+        // Public API students can use to record call-stack entries from JS.
+        //
+        //   webideTrace.tap('name', arg1, arg2);
+        //       Record a single sibling entry in the call tape. Use this for
+        //       simple logging — no push/pop, no nesting.
+        //
+        //   webideTrace.call('fact', n);  ...;  return webideTrace.return(result);
+        //       Record a scope. .call opens a frame, .return closes it. Use
+        //       this when you want to see recursion or nested calls. EVERY
+        //       .call must have a matching .return — otherwise later .call()s
+        //       end up appearing nested inside it. (The renderer adds a
+        //       "(no return)" marker on unclosed frames to make this obvious.)
+        function _webideFormatArgs(args) {
+            return Array.prototype.map.call(args, a => {
+                try {
+                    if (typeof a === 'string') return JSON.stringify(a).slice(0, 40);
+                    if (typeof a === 'object' && a !== null) return JSON.stringify(a).slice(0, 40);
+                    return String(a);
+                } catch (e) { return '?'; }
+            }).join(', ');
+        }
+        function _webideFormatReturn(value) {
+            try {
+                if (typeof value === 'string') return JSON.stringify(value).slice(0, 80);
+                if (typeof value === 'object' && value !== null) return JSON.stringify(value).slice(0, 80);
+                return String(value);
+            } catch (e) { return '?'; }
+        }
+        window.webideTrace = {
+            _root: { name: '<top>', args: '', children: [], returnValue: null, exception: null },
+            _stack: null,
+            _reset: function() {
+                this._root = { name: '<top>', args: '', children: [], returnValue: null, exception: null };
+                this._stack = [this._root];
+            },
+            // Sibling logger — no stack manipulation. Best default for
+            // "I just want to see when this function ran".
+            tap: function(name) {
+                if (!this._stack) this._reset();
+                const argStr = _webideFormatArgs(Array.prototype.slice.call(arguments, 1));
+                const node = {
+                    name: String(name), args: argStr, children: [],
+                    returnValue: null, exception: null, isTap: true,
+                };
+                this._stack[this._stack.length - 1].children.push(node);
+            },
+            // Scope open — pushes a new frame. Must be paired with .return().
+            call: function(name) {
+                if (!this._stack) this._reset();
+                const argStr = _webideFormatArgs(Array.prototype.slice.call(arguments, 1));
+                const node = {
+                    name: String(name), args: argStr, children: [],
+                    returnValue: null, exception: null,
+                    t_start: (typeof performance !== 'undefined' ? performance.now() : Date.now()),
+                    duration_ms: 0,
+                };
+                this._stack[this._stack.length - 1].children.push(node);
+                this._stack.push(node);
+            },
+            // Scope close — pops the topmost frame and records the return.
+            return: function(value) {
+                if (!this._stack || this._stack.length <= 1) return value;
+                const node = this._stack.pop();
+                node.returnValue = _webideFormatReturn(value);
+                const now = (typeof performance !== 'undefined' ? performance.now() : Date.now());
+                node.duration_ms = now - (node.t_start || now);
+                return value;
+            }
+        };
+
+        // JS-only: capture top-level globals before/after eval to compute a diff
+        let _windowKeysBaseline = null;
+        function snapshotJsGlobalsBefore() {
+            try { _windowKeysBaseline = new Set(Object.keys(window)); }
+            catch (e) { _windowKeysBaseline = null; }
+        }
+        function snapshotJsGlobalsAfter() {
+            if (!_windowKeysBaseline) return null;
+            const newKeys = Object.keys(window).filter(k => !_windowKeysBaseline.has(k));
+            const out = {};
+            for (const k of newKeys) {
+                // Skip our own internals and conventional Python-style dunders,
+                // but allow leading-underscore names like _count / _word that
+                // students might legitimately use.
+                if (k.startsWith('__webide') || k.startsWith('_webide')) continue;
+                if (k.startsWith('webideTrace')) continue;
+                if (k === 'feedbackString' || k === 'PROCESSING_CODE_BEGIN' || k === 'PROCESSING_CODE_END') continue;
+                try {
+                    const v = window[k];
+                    let tname, strVal;
+                    if (v === null) { tname = 'null'; strVal = 'null'; }
+                    else if (Array.isArray(v)) {
+                        tname = 'array';
+                        try { strVal = JSON.stringify(v).slice(0, 200); } catch (e) { strVal = '[Array]'; }
+                    }
+                    else if (typeof v === 'function') { tname = 'function'; strVal = '<function ' + (v.name || '?') + '>'; }
+                    else if (typeof v === 'object') {
+                        tname = 'object';
+                        try { strVal = JSON.stringify(v).slice(0, 200); } catch (e) { strVal = '[Object]'; }
+                    }
+                    else { tname = typeof v; strVal = String(v); }
+                    if (strVal && strVal.length > 200) strVal = strVal.slice(0, 200) + '...';
+                    out[k] = { type: tname, value: strVal };
+                } catch (e) {}
+            }
+            return out;
+        }
+
+        function _beforeRun() {
+            if (window.webideTrace) window.webideTrace._reset();
+            window.__webide_vars = null;
+            window.__webide_steps = null;
+            window.__webide_calltree = null;
+            snapshotJsGlobalsBefore();
+            // Step Run mode: swap in the traced Python runner for this one call
+            if (_stepRunRequested && _LANG_FAMILY === 'python' && window.run_python_code_traced) {
+                window._webide_orig_run_python = window.run_python_code;
+                window.run_python_code = window.run_python_code_traced;
+            }
+        }
+        function _afterRun() {
+            if (window._webide_orig_run_python) {
+                window.run_python_code = window._webide_orig_run_python;
+                window._webide_orig_run_python = null;
+            }
+            _stepRunRequested = false;
+            _inspectorState.hasRun = true;
+            refreshInspectorFromRun();
+            // Bump attempt counter for the hint ladder. We bump here (not
+            // in checkAnswer) so that even runs that error out before reaching
+            // the autograder count as "tried it".
+            try {
+                _setHintAttempts(_getHintAttempts() + 1);
+                _renderHintLadder();
+            } catch (e) {}
+            // Snapshot run history so students can restore any of the last 20
+            // attempts. We swallow errors because losing one snapshot must
+            // never break the Run flow.
+            try {
+                if (typeof recordRunSnapshot === 'function') {
+                    // Async fire-and-forget — fileystem read may take a moment
+                    recordRunSnapshot();
+                }
+            } catch (e) {}
+        }
+
+        function refreshInspectorFromRun() {
+            // Variables: prefer Python's __webide_vars, else JS-side diff.
+            // The JS diff is only meaningful for JavaScript exercises — on
+            // Java (Processing.js) or Graphics pages it would surface
+            // unhelpful runtime internals like $P, so skip it there.
+            let vars = null;
+            if (window.__webide_vars && typeof window.__webide_vars === 'object') {
+                vars = {};
+                for (const k of Object.keys(window.__webide_vars)) {
+                    const v = window.__webide_vars[k];
+                    vars[k] = (v && typeof v === 'object' && 'type' in v) ? v : { type: typeof v, value: String(v) };
+                }
+            } else if (_PAGE_LANG === 'javascript') {
+                vars = snapshotJsGlobalsAfter();
+            }
+            _inspectorState.vars = vars;
+
+            // Steps (Python traced run only)
+            if (window.__webide_steps && window.__webide_steps.length) {
+                const steps = [];
+                for (let i = 0; i < window.__webide_steps.length; i++) {
+                    const s = window.__webide_steps[i];
+                    const locals = {};
+                    if (s.locals) {
+                        for (const k of Object.keys(s.locals)) {
+                            const cell = s.locals[k];
+                            locals[k] = { type: cell.type, value: cell.value };
+                        }
+                    }
+                    steps.push({ lineno: s.lineno, function: s.function, locals });
+                }
+                _inspectorState.steps = steps;
+                _inspectorState.currentStep = 0;
+            }
+
+            // Call tree: Python settrace, or JS webideTrace
+            if (window.__webide_calltree) {
+                _inspectorState.callTree = jsifyCallTree(window.__webide_calltree);
+            } else if (window.webideTrace && window.webideTrace._root && window.webideTrace._root.children.length) {
+                _inspectorState.callTree = window.webideTrace._root;
+            }
+            renderInspector();
+        }
+
+        function jsifyCallTree(node) {
+            const out = {
+                name: node.name, args: node.args,
+                returnValue: node.returnValue, exception: node.exception,
+                lineno: node.lineno || 0, children: []
+            };
+            if (node.children) {
+                for (let i = 0; i < node.children.length; i++) {
+                    out.children.push(jsifyCallTree(node.children[i]));
+                }
+            }
+            return out;
+        }
+
+        function renderInspector() {
+            renderInspectorVars();
+            renderInspectorSteps();
+            renderInspectorTree();
+            renderInspectorProfile();
+            renderInspectorVisualize();
+        }
+
+        // -- Profile sub-tab: aggregate call-tree timing per function ---------
+        function _flattenProfile(node, agg) {
+            if (!node) return;
+            for (const c of (node.children || [])) {
+                const dur = (c.duration_ms || 0);
+                let childrenDur = 0;
+                for (const cc of (c.children || [])) childrenDur += (cc.duration_ms || 0);
+                const self = Math.max(0, dur - childrenDur);
+                const e = agg[c.name] || { name: c.name, calls: 0, self_ms: 0, total_ms: 0, longest_ms: 0 };
+                e.calls   += 1;
+                e.self_ms += self;
+                e.total_ms += dur;
+                if (dur > e.longest_ms) e.longest_ms = dur;
+                agg[c.name] = e;
+                _flattenProfile(c, agg);
+            }
+        }
+        function renderInspectorProfile() {
+            const view = document.getElementById('inspector-profile');
+            if (!view) return;
+            const tree = _inspectorState.callTree;
+            if (!tree || !tree.children || !tree.children.length) {
+                let hint = 'Run your code to see a profile.';
+                if (_inspectorState.hasRun) {
+                    hint = 'No call events recorded. Pyodide records automatically — for JavaScript or Java/Processing, add <code class="code-inline">webideTrace.call()</code> / <code class="code-inline">webideTrace.return()</code> around the function you want to time.';
+                }
+                view.innerHTML = '<div class="inspector-empty">' + hint + '</div>';
+                return;
+            }
+            const agg = {};
+            _flattenProfile(tree, agg);
+            const rows = Object.values(agg).sort((a, b) => b.self_ms - a.self_ms);
+            const fmt = (ms) => ms < 1 ? ms.toFixed(2) + ' ms' : ms.toFixed(1) + ' ms';
+            let html = '<table style="width:100%; font-size:11px; border-collapse:collapse;">'
+                + '<thead><tr style="text-align:left; opacity:0.7;">'
+                + '<th style="padding:4px 6px;">function</th>'
+                + '<th style="padding:4px 6px;">calls</th>'
+                + '<th style="padding:4px 6px;">self</th>'
+                + '<th style="padding:4px 6px;">total</th>'
+                + '<th style="padding:4px 6px;">longest</th>'
+                + '</tr></thead><tbody>';
+            for (const r of rows) {
+                html += '<tr style="border-top:1px solid rgba(255,255,255,0.06);">'
+                    + '<td style="padding:3px 6px; color:#9cdcfe;">' + r.name + '</td>'
+                    + '<td style="padding:3px 6px;">' + r.calls + '</td>'
+                    + '<td style="padding:3px 6px;">' + fmt(r.self_ms) + '</td>'
+                    + '<td style="padding:3px 6px;">' + fmt(r.total_ms) + '</td>'
+                    + '<td style="padding:3px 6px;">' + fmt(r.longest_ms) + '</td>'
+                    + '</tr>';
+            }
+            html += '</tbody></table>';
+            view.innerHTML = html;
+        }
+
+        // -- Visualize sub-tab: render locals from the current step as SVG.
+        // Walks the step's locals dict; lists become indexed boxes, dicts
+        // become key:value rows. Pure SVG — no d3 dependency.
+        function _vizNodeForValue(name, value, x, y) {
+            // Returns an <svg fragment> string. y is the top y-coord.
+            const w = 220;
+            const head = name + ' = ';
+            let body, color;
+            if (value && typeof value === 'object' && 'type' in value && 'value' in value) {
+                color = value.type === 'list' || value.type === 'array' ? '#ce9178'
+                      : value.type === 'dict'  || value.type === 'object' ? '#9cdcfe'
+                      : '#dcdcaa';
+                body = head + (value.value || '');
+            } else {
+                color = '#dcdcaa';
+                body = head + String(value);
+            }
+            const safe = (s) => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+            return '<g transform="translate(' + x + ',' + y + ')">'
+                +    '<rect width="' + w + '" height="34" rx="4" '
+                +    'fill="rgba(80,80,90,0.25)" stroke="' + color + '" stroke-width="1.5"/>'
+                +    '<text x="8" y="22" font-family="Consolas,monospace" font-size="12" '
+                +    'fill="' + color + '">' + safe(body.slice(0, 32)) + '</text>'
+                + '</g>';
+        }
+        function renderInspectorVisualize() {
+            const view = document.getElementById('inspector-visualize');
+            if (!view) return;
+            // Take the locals of the current step (if any); else the variables.
+            let locals = null;
+            const steps = _inspectorState.steps || [];
+            if (steps.length) locals = steps[_inspectorState.currentStep | 0]?.locals || null;
+            else if (_inspectorState.vars) locals = _inspectorState.vars;
+            if (!locals || !Object.keys(locals).length) {
+                let hint = 'Run your code (with a breakpoint or Step Run) to visualize variables.';
+                if (_inspectorState.hasRun) hint = 'No variables in scope at the current step.';
+                view.innerHTML = '<div class="inspector-empty">' + hint + '</div>';
+                return;
+            }
+            const keys = Object.keys(locals);
+            const rows = keys.length;
+            const cols = 2;
+            const cellW = 240, cellH = 44, padX = 12, padY = 8;
+            const W = cellW * cols + padX;
+            const H = Math.ceil(rows / cols) * cellH + padY;
+            let svg = '<svg width="' + W + '" height="' + H + '" xmlns="http://www.w3.org/2000/svg" '
+                + 'style="font-family:Consolas,monospace; max-width:100%;">';
+            keys.forEach((k, i) => {
+                const col = i % cols, row = Math.floor(i / cols);
+                svg += _vizNodeForValue(k, locals[k], col * cellW, row * cellH);
+            });
+            svg += '</svg>';
+            view.innerHTML = svg;
+        }
+        // Exposed so external callers (browser console, tests) can re-render
+        // the Inspector after manually populating webideTrace or
+        // window.__webide_vars from outside the normal Run pipeline.
+        window.refreshInspectorFromRun = refreshInspectorFromRun;
+        window.renderInspector = renderInspector;
+
+        function renderInspectorVars() {
+            const view = document.getElementById('inspector-vars');
+            if (!view) return;
+            const vars = _inspectorState.vars;
+            if (!vars || Object.keys(vars).length === 0) {
+                let msg;
+                if (!_inspectorState.hasRun) {
+                    msg = 'Run your code to inspect variables.';
+                } else if (_LANG_FAMILY === 'python' || _LANG_FAMILY === 'javascript') {
+                    msg = 'No top-level variables were captured this run. '
+                        + '(Assignments inside functions are local to those functions and don\'t show here. '
+                        + 'Set a breakpoint inside the function with F9 to inspect locals.)';
+                } else if (_PAGE_LANG === 'sql' || _PAGE_LANG === 'prolog' ||
+                           _PAGE_LANG === 'scheme' || _PAGE_LANG === 'cpp' ||
+                           _PAGE_LANG === 'java' || _PAGE_LANG === 'graphics_view' ||
+                           _PAGE_LANG === 'graphics_shader') {
+                    msg = 'No variables captured this run. For this language, set a breakpoint '
+                        + 'on a line of interest (F9 or click the gutter) to record values at that point.';
+                } else {
+                    msg = 'Variable inspection is supported via breakpoints for this language. '
+                        + 'Use F9 to set one.';
+                }
+                view.innerHTML = '<div class="inspector-empty">' + msg + '</div>';
+                return;
+            }
+            view.innerHTML = '';
+            for (const k of Object.keys(vars)) {
+                const v = vars[k];
+                const row = document.createElement('div');
+                row.className = 'inspector-var-row';
+                const nameEl = document.createElement('span');
+                nameEl.className = 'inspector-var-name';
+                nameEl.textContent = k;
+                const typeEl = document.createElement('span');
+                typeEl.className = 'inspector-var-type';
+                typeEl.textContent = (v && v.type) ? v.type : typeof v;
+                const valEl = document.createElement('span');
+                valEl.className = 'inspector-var-value';
+                valEl.textContent = (v && 'value' in v) ? v.value : String(v);
+                row.appendChild(nameEl);
+                row.appendChild(typeEl);
+                row.appendChild(valEl);
+                view.appendChild(row);
+            }
+        }
+
+        function renderInspectorSteps() {
+            const view = document.getElementById('inspector-steps');
+            if (!view) return;
+            const steps = _inspectorState.steps;
+            if (!steps || steps.length === 0) {
+                const msg = (_LANG_FAMILY === 'python')
+                    ? 'Click <strong>Step Run</strong> above to record execution steps.'
+                    : 'Step-Through is available for Python.';
+                view.innerHTML = '<div class="inspector-empty">' + msg + '</div>';
+                return;
+            }
+            let cur = _inspectorState.currentStep | 0;
+            if (cur < 0) cur = 0;
+            if (cur >= steps.length) cur = steps.length - 1;
+            _inspectorState.currentStep = cur;
+
+            view.innerHTML =
+                '<div class="step-controls">' +
+                  '<button class="step-btn" id="step-first" aria-label="Jump to first step" title="First">⏮</button>' +
+                  '<button class="step-btn" id="step-prev" aria-label="Previous step" title="Previous">◀</button>' +
+                  '<button class="step-btn" id="step-next" aria-label="Next step" title="Next">▶</button>' +
+                  '<button class="step-btn" id="step-last" aria-label="Jump to last step" title="Last">⏭</button>' +
+                  '<span class="step-progress" id="step-progress"></span>' +
+                '</div>' +
+                '<div class="step-display">' +
+                  '<div class="step-pane">' +
+                    '<h5>Where</h5>' +
+                    '<div>Function: <strong class="step-fn"></strong></div>' +
+                    '<div class="step-line-display">' +
+                      '<span class="step-line-num"></span><span class="step-line-code"></span>' +
+                    '</div>' +
+                  '</div>' +
+                  '<div class="step-pane step-locals">' +
+                    '<h5>Local Variables</h5>' +
+                    '<div class="step-locals-list"></div>' +
+                  '</div>' +
+                '</div>';
+
+            const updateStep = () => {
+                const i = _inspectorState.currentStep;
+                const s = steps[i];
+                view.querySelector('#step-progress').textContent = 'Step ' + (i + 1) + ' of ' + steps.length;
+                view.querySelector('.step-fn').textContent = s.function || '<module>';
+                view.querySelector('.step-line-num').textContent = 'Line ' + s.lineno + '  ';
+                view.querySelector('.step-line-code').textContent = getEditorLine(s.lineno) || '';
+                const list = view.querySelector('.step-locals-list');
+                list.innerHTML = '';
+                const locals = s.locals || {};
+                const keys = Object.keys(locals);
+                if (keys.length === 0) {
+                    list.innerHTML = '<div style="color:#888; font-style:italic;">(no locals)</div>';
+                } else {
+                    for (const k of keys) {
+                        const v = locals[k];
+                        const row = document.createElement('div');
+                        row.className = 'inspector-var-row';
+                        const n = document.createElement('span'); n.className = 'inspector-var-name'; n.textContent = k;
+                        const t = document.createElement('span'); t.className = 'inspector-var-type'; t.textContent = v.type;
+                        const vEl = document.createElement('span'); vEl.className = 'inspector-var-value'; vEl.textContent = v.value;
+                        row.appendChild(n); row.appendChild(t); row.appendChild(vEl);
+                        list.appendChild(row);
+                    }
+                }
+                // ACE highlight the line for visual feedback
+                try {
+                    if (ace_editor) {
+                        if (_inspectorState._lineMarkerId) {
+                            ace_editor.session.removeMarker(_inspectorState._lineMarkerId);
+                            _inspectorState._lineMarkerId = null;
+                        }
+                        const Range = ace.require('ace/range').Range;
+                        _inspectorState._lineMarkerId = ace_editor.session.addMarker(
+                            new Range(s.lineno - 1, 0, s.lineno - 1, 1),
+                            'webide-step-marker', 'fullLine');
+                        ace_editor.gotoLine(s.lineno, 0, false);
+                    }
+                } catch (e) {}
+            };
+            view.querySelector('#step-first').addEventListener('click', () => { _inspectorState.currentStep = 0; updateStep(); });
+            view.querySelector('#step-last').addEventListener('click',  () => { _inspectorState.currentStep = steps.length - 1; updateStep(); });
+            view.querySelector('#step-prev').addEventListener('click',  () => { if (_inspectorState.currentStep > 0) { _inspectorState.currentStep--; updateStep(); } });
+            view.querySelector('#step-next').addEventListener('click',  () => { if (_inspectorState.currentStep < steps.length - 1) { _inspectorState.currentStep++; updateStep(); } });
+            updateStep();
+        }
+
+        function renderInspectorTree() {
+            const view = document.getElementById('inspector-trace');
+            if (!view) return;
+            const tree = _inspectorState.callTree;
+            if (!tree || !tree.children || tree.children.length === 0) {
+                const hint = (_LANG_FAMILY === 'python')
+                    ? 'Use <strong>Step Run</strong> to capture function calls.'
+                    : 'These helpers are <strong>markers, not invokers</strong> — they only label this tape.<br>'
+                        + '<strong>tap:</strong> '
+                        + '<code class="code-inline">webideTrace.tap(\'fname\', arg1)</code> '
+                        + 'adds one sibling entry (simple log).<br>'
+                        + '<strong>call/return:</strong> put '
+                        + '<code class="code-inline">webideTrace.call(\'fname\', args)</code> as the '
+                        + 'first line <em>inside</em> the function, and '
+                        + '<code class="code-inline">return webideTrace.return(value)</code> at every '
+                        + 'return statement. Then call the function normally. (Three call()s with no '
+                        + 'return()s in between end up nested — use tap() for that.)';
+                view.innerHTML = '<div class="inspector-empty">No call tape recorded.<br>' + hint + '</div>';
+                return;
+            }
+            view.innerHTML = '';
+            // Count calls, max depth, and unclosed call() frames so we can warn
+            let totalCalls = 0, maxDepth = 0, unclosed = 0;
+            const count = (node, depth) => {
+                totalCalls++;
+                if (depth > maxDepth) maxDepth = depth;
+                // A node is "unclosed" if it was created by .call() (not .tap()),
+                // has no recorded return, has no exception, and yet has children
+                // — that means another call() was issued before the matching
+                // return(). True leaves with no children and no return are
+                // ambiguous (could be in-progress or just never called .return),
+                // but tap() nodes explicitly set isTap and are excluded here.
+                if (!node.isTap && node.returnValue == null && !node.exception
+                        && node.children && node.children.length > 0) {
+                    unclosed++;
+                }
+                for (const c of (node.children || [])) count(c, depth + 1);
+            };
+            for (const c of tree.children) count(c, 1);
+            const summary = document.createElement('div');
+            summary.className = 'calltape-summary';
+            summary.textContent = totalCalls + ' call' + (totalCalls === 1 ? '' : 's')
+                + ', max depth ' + maxDepth
+                + (unclosed > 0 ? '  ·  ' + unclosed + ' unclosed (missing .return)' : '');
+            view.appendChild(summary);
+
+            const root = document.createElement('div');
+            root.className = 'calltape-tree';
+            const renderNode = (node, container, depth) => {
+                const wrap = document.createElement('div');
+                wrap.className = 'calltape-node';
+                if (depth === 0) wrap.style.marginLeft = '0';
+                const line = document.createElement('div');
+                line.className = 'calltape-call';
+                const hasKids = node.children && node.children.length > 0;
+                const tog = document.createElement('span');
+                tog.className = 'calltape-toggle';
+                tog.textContent = hasKids ? '▼' : ' ';
+                line.appendChild(tog);
+                const fname = document.createElement('span');
+                fname.className = 'calltape-fname';
+                fname.textContent = node.name;
+                line.appendChild(fname);
+                line.appendChild(document.createTextNode('(' + (node.args || '') + ')'));
+                if (node.exception) {
+                    const ex = document.createElement('span');
+                    ex.className = 'calltape-throw';
+                    ex.textContent = '  ⚡ ' + node.exception;
+                    line.appendChild(ex);
+                } else if (node.returnValue != null && node.returnValue !== 'None' && node.returnValue !== 'undefined') {
+                    const arrow = document.createElement('span');
+                    arrow.className = 'calltape-arrow';
+                    arrow.textContent = '→';
+                    const ret = document.createElement('span');
+                    ret.className = 'calltape-return';
+                    ret.textContent = node.returnValue;
+                    line.appendChild(arrow);
+                    line.appendChild(ret);
+                } else if (!node.isTap && node.returnValue == null && hasKids) {
+                    // call() that never .return()'d — flag it so the user
+                    // knows the visible nesting under it is an artifact of
+                    // the missing return, not real recursion. Common cause:
+                    // calling webideTrace.call('foo') three times in a row
+                    // thinking it invokes foo() — it doesn't, it just pushes
+                    // a label that needs a matching .return.
+                    const warn = document.createElement('span');
+                    warn.className = 'calltape-unclosed';
+                    warn.textContent = '  (no .return — try webideTrace.tap() for sibling logging)';
+                    line.appendChild(warn);
+                }
+                wrap.appendChild(line);
+                if (hasKids) {
+                    const kids = document.createElement('div');
+                    kids.className = 'calltape-children';
+                    for (const c of node.children) renderNode(c, kids, depth + 1);
+                    wrap.appendChild(kids);
+                    tog.style.cursor = 'pointer';
+                    tog.addEventListener('click', () => {
+                        const coll = kids.classList.toggle('collapsed');
+                        tog.textContent = coll ? '▶' : '▼';
+                    });
+                }
+                container.appendChild(wrap);
+            };
+            for (const c of tree.children) renderNode(c, root, 0);
+            view.appendChild(root);
+        }
+
+        function getEditorLine(lineno) {
+            try {
+                if (!ace_editor) return '';
+                const sess = ace_editor.session;
+                if (lineno < 1 || lineno > sess.getLength()) return '';
+                return sess.getLine(lineno - 1);
+            } catch (e) { return ''; }
+        }
+        window.getEditorLine = getEditorLine;
+
+        // Inspector sub-tab switching
+        window.switchInspectorView = (name) => {
+            document.querySelectorAll('.inspector-subtab').forEach(t => {
+                const isActive = t.id === 'insub-' + name;
+                t.classList.toggle('active', isActive);
+                t.setAttribute('aria-selected', isActive ? 'true' : 'false');
+                t.setAttribute('tabindex', isActive ? '0' : '-1');
+            });
+            document.querySelectorAll('.inspector-view').forEach(v => {
+                const isActive = v.id === 'inspector-' + name;
+                v.classList.toggle('active', isActive);
+                if (isActive) v.removeAttribute('hidden');
+                else          v.setAttribute('hidden', '');
+            });
+        };
+
+        // Step Run button: re-runs in Python tracing mode
+        const _stepRunBtn = document.getElementById('inspector-step-run');
+        if (_stepRunBtn) {
+            // Hide for non-Python languages
+            if (_LANG_FAMILY !== 'python') _stepRunBtn.style.display = 'none';
+            _stepRunBtn.addEventListener('click', () => {
+                if (_LANG_FAMILY !== 'python') {
+                    if (typeof ideNotify === 'function') ideNotify('Step Run is currently available for Python.', 'error');
+                    return;
+                }
+                _stepRunRequested = true;
+                if (!runBtn.disabled) runBtn.click();
+                switchBottomTab('inspector');
+                setTimeout(() => switchInspectorView('steps'), 80);
+            });
+        }
 
         function saveActiveTabs() {
             logToConsole("Saving open tabs...");
@@ -2625,6 +5086,10 @@ def pyodide_print(s):
             await waitForElement('#editor-container');
 
             ace_editor = ace.edit("editor-container");
+            // Expose for tests + extensions (parallels the pattern used for
+            // pyodide / refreshInspectorFromRun). Internal callers still use
+            // the let-binding above; this is a one-way mirror.
+            window.ace_editor = ace_editor;
             ace_editor.setTheme("ace/theme/monokai");
             ace_editor.setFontSize(14);
             ace_editor.setOptions({
@@ -2634,6 +5099,10 @@ def pyodide_print(s):
                 enableBasicAutocompletion: true,
                 enableSnippets: true
             });
+            // Re-apply persisted preferences once the editor exists
+            if (typeof window.__webideApplyPrefs === 'function') {
+                try { window.__webideApplyPrefs(); } catch (e) {}
+            }
             // Screen reader mode provides a textarea that screen readers can interact with
             ace_editor.setOption('enableEmmet', false);
             try { ace_editor.renderer.setOption('screenReaderMode', true); } catch(e) {}
@@ -2647,12 +5116,28 @@ def pyodide_print(s):
             ace_editor.session.on('change', function() {
                 // Don't mark as modified if we're programmatically setting the value
                 if (window._settingEditorValue) return;
-                
+
                 const activeTab = document.querySelector('.tab.active');
                 if (activeTab && openFiles[activeTab.id]) {
                     openFiles[activeTab.id].content = ace_editor.getValue();
                     openFiles[activeTab.id].modified = true;
                 }
+            });
+
+            // -- Breakpoint gutter handler ---------------------------------
+            // Click a gutter row to toggle a red-dot breakpoint. Right-click
+            // is reserved for the host browser's context menu, so we use the
+            // F9 shortcut + Run menu for "clear all".
+            ace_editor.on('guttermousedown', function(e) {
+                const target = e.domEvent.target;
+                // Ignore folding widgets and other non-line clicks
+                if (!target.classList.contains('ace_gutter-cell')) return;
+                if (e.clientX > target.getBoundingClientRect().left + 18) return;
+                const row = e.getDocumentPosition().row;  // 0-based
+                const path = _getActivePath();
+                if (!path) return;
+                toggleBreakpoint(path, row + 1);
+                e.stop();
             });
 
             // Update status bar line/col
@@ -2827,7 +5312,27 @@ def pyodide_print(s):
                 if (doPrint !== false) logToConsole(state + ' ' + status);
                 this.state = state;
             }
-            print({ text })    { this.text += text + "\n"; }
+            print({ text })    {
+                // Strip C/C++ breakpoint markers and emit them as hits. The
+                // text comes in chunks of arbitrary size, so we buffer a
+                // partial line if the chunk ends mid-marker.
+                if (this.name === 'runtime' && text && typeof text === 'string' && text.indexOf('__BP') !== -1) {
+                    const buf = (this._bpBuf || '') + text;
+                    const lines = buf.split('\n');
+                    this._bpBuf = lines.pop();
+                    const clean = [];
+                    for (const ln of lines) {
+                        const m = ln.match(/^__BP\s+(\d+)\s*$/);
+                        if (m) {
+                            try { window.__webide_bp(+m[1], { lang: 'cpp' }); } catch (e) {}
+                        } else {
+                            clean.push(ln);
+                        }
+                    }
+                    text = clean.join('\n') + (clean.length ? '\n' : '');
+                }
+                this.text += text + "\n";
+            }
             printErr({ text }) { this.text += text + "\n"; }
         }
 
@@ -2921,6 +5426,16 @@ def pyodide_print(s):
             clang.state = 'busy';
             let codeText = await getCodeText();
             let mainText = await getMainCodeText();
+            // Trace-on-hit for C/C++: inject printf markers BEFORE the stdio
+            // patch so the line numbers we instrument match what the student
+            // sees in the gutter. The runtime worker echoes them to stdout,
+            // and a print-hook below strips them out + emits hits.
+            try {
+                const _bpLines = window.__webide_activeBreakpointLines() || [];
+                if (_bpLines.length && window.webideInstrumentForBreakpoints) {
+                    codeText = window.webideInstrumentForBreakpoints(codeText, 'cpp', _bpLines);
+                }
+            } catch (e) {}
             // The wasm sysroot ships a corrupted /usr/include/libcxx/stdio.h that
             // contains C++ forward_list template fragments instead of C stdio declarations.
             // We pre-define its include guard and supply correct C-style declarations
@@ -2973,6 +5488,13 @@ def pyodide_print(s):
         async function doScheme(codeString, mainString) {
             feedbackString = "";
             let code = codeString + '\n' + mainString + '\n';
+            // Trace-on-hit: inject (webide-bp N) calls at each breakpoint line.
+            try {
+                const _bpLines = window.__webide_activeBreakpointLines();
+                if (_bpLines && _bpLines.length && window.webideInstrumentForBreakpoints) {
+                    code = window.webideInstrumentForBreakpoints(code, 'scheme', _bpLines);
+                }
+            } catch (e) { /* tolerate */ }
             onSchemeError  = e => logToConsole(e.message);
             onSchemeResult = result => {
                 if (result == BiwaScheme.undef || result == null || result == undefined) {
@@ -2983,6 +5505,17 @@ def pyodide_print(s):
                 }
             };
             biwa = new BiwaScheme.Interpreter(onSchemeError);
+            // Define `webide-bp` as a side-effect-only primitive that records
+            // the hit via the standard __webide_bp helper. Use define_libfunc
+            // when available; fall back to evaluating a Scheme stub.
+            try {
+                if (typeof BiwaScheme.define_libfunc === 'function') {
+                    BiwaScheme.define_libfunc('webide-bp', 1, 1, function(ar) {
+                        try { window.__webide_bp(ar[0] | 0, {}); } catch (e) {}
+                        return BiwaScheme.undef;
+                    });
+                }
+            } catch (e) { /* if already defined or undefined, ignore */ }
             return biwa.evaluate(code, onSchemeResult);
         }
         {% endif %}
@@ -2992,16 +5525,38 @@ def pyodide_print(s):
         async function doSql(codeString, mainString) {
             feedbackString = "";
             let code = mainString + '\n' + codeString + '\n';
+            // Trace-on-hit: insert `-- __BP N` marker comments at breakpoint
+            // lines, then collect them per-statement below.
+            try {
+                const _bpLines = window.__webide_activeBreakpointLines();
+                if (_bpLines && _bpLines.length && window.webideInstrumentForBreakpoints) {
+                    code = window.webideInstrumentForBreakpoints(code, 'sql', _bpLines);
+                }
+            } catch (e) {}
             const config = { locateFile: fn => "{{site.baseurl}}/assets/js/sql.js/sql.js" };
             await initSqlJs(config).then(function(SQL) {
                 const db = new SQL.Database();
                 code.split(';').forEach(rawStmt => {
+                    // Pull out __BP markers BEFORE the comment-strip step.
+                    const hits = [];
+                    rawStmt.split('\n').forEach(l => {
+                        const m = l.match(/--\s*__BP\s+(\d+)/);
+                        if (m) hits.push(+m[1]);
+                    });
                     let stmt = rawStmt.split('\n')
                         .filter(l => !l.trim().startsWith('--') && l.trim().length > 0)
                         .join(' ') + ';';
                     if (stmt.trim().length > 1) {
                         const res = db.exec(stmt);
                         feedbackString += JSON.stringify(res) + '\n';
+                        // Emit one bp hit per marker in this statement, with the
+                        // result rowcount + columns as the "locals" so students
+                        // can inspect the effect of each breakpointed query.
+                        for (const ln of hits) {
+                            const rowCount = (res[0] && res[0].values) ? res[0].values.length : 0;
+                            const cols = (res[0] && res[0].columns) ? res[0].columns.join(',') : '';
+                            try { window.__webide_bp(ln, { rows: rowCount, columns: cols }); } catch (e) {}
+                        }
                     }
                 });
                 logToConsole(feedbackString);
@@ -3021,6 +5576,10 @@ def pyodide_print(s):
 
         async function setupPyodide() {
             pyodide = await loadPyodide();
+            // Expose on window so other scripts, the browser console, and the
+            // test suite can interact with Pyodide directly (e.g. to invoke
+            // Step Run tracer machinery without going through the file system).
+            window.pyodide = pyodide;
             logToConsole("Importing packages {{page.info.packages}}...");
             for (let i = 0; i < packages.length; i++) await pyodide.loadPackage(packages[i]);
             logToConsole("Finished loading packages. You can run your code now.");
@@ -3194,7 +5753,93 @@ def pyodide_print(s):
                 {% elsif page.language == "pyodide" %}
                 if (!pyodideLoaded) await pyodidePromise;
                 let student_code = editorText + "\n\n" + document.getElementById("pyodideBoilerplate").innerHTML + "\n\n" + mainText;
-                pyodide.runPython(student_code);
+                const _webideStepMode = _stepRunRequested;
+                // Pyodide breakpoint mode: enabled when the user set gutter
+                // breakpoints but did NOT click Step Run. Uses a different
+                // tracer that records only breakpoint-hit lines.
+                const _webideBpLines = window.__webide_activeBreakpointLines() || [];
+                const _webideBpMode  = !_webideStepMode && _webideBpLines.length > 0;
+                if (_webideStepMode) {
+                    try {
+                        // 1) Load the tracer + state. Does NOT install settrace —
+                        //    that happens inside the student wrapper.
+                        pyodide.runPython(document.getElementById('pyodideStepPrologue').textContent);
+                        // 2) Hand the student source to Python as a variable.
+                        pyodide.globals.set('_webide_student_source', student_code);
+                        // 3) Run a small Python wrapper that compile()s the
+                        //    student source with a unique co_filename, installs
+                        //    settrace, exec's the compiled code, and uninstalls
+                        //    settrace via try/finally. This guarantees that the
+                        //    only frames seen by the tracer are student frames.
+                        pyodide.runPython(document.getElementById('pyodideStepExec').textContent);
+                    } catch (e) {
+                        console.error('Step Run failed:', e);
+                    }
+                } else if (_webideBpMode) {
+                    try {
+                        pyodide.runPython(document.getElementById('pyodideBpPrologue').textContent);
+                        pyodide.globals.set('_webide_student_source', student_code);
+                        // Use Python set literal syntax to seed the bp lines
+                        const bpLiteral = '{' + _webideBpLines.map(n => String(+n)).join(',') + (_webideBpLines.length === 1 ? ',}' : '}');
+                        pyodide.runPython('_webide_bp_lines = ' + bpLiteral);
+                        pyodide.runPython(document.getElementById('pyodideBpExec').textContent);
+                    } catch (e) {
+                        console.error('Breakpoint run failed:', e);
+                    }
+                } else {
+                    pyodide.runPython(student_code);
+                }
+                if (_webideStepMode) {
+                    try {
+                        // Read out steps + call tree as JS objects
+                        const stepsPy = pyodide.globals.get('_webide_steps');
+                        const treePy  = pyodide.globals.get('_webide_calltree');
+                        if (stepsPy) {
+                            window.__webide_steps = stepsPy.toJs({ dict_converter: Object.fromEntries });
+                            stepsPy.destroy && stepsPy.destroy();
+                        }
+                        if (treePy) {
+                            window.__webide_calltree = treePy.toJs({ dict_converter: Object.fromEntries });
+                            treePy.destroy && treePy.destroy();
+                        }
+                    } catch (e) { console.error('Step epilogue failed:', e); }
+                } else if (_webideBpMode) {
+                    try {
+                        const stepsPy = pyodide.globals.get('_webide_bp_steps');
+                        if (stepsPy) {
+                            window.__webide_steps = stepsPy.toJs({ dict_converter: Object.fromEntries });
+                            stepsPy.destroy && stepsPy.destroy();
+                            // Console breadcrumbs so students notice the hits
+                            if ((window.__webide_steps || []).length) {
+                                logToConsole('[breakpoints] hit ' + window.__webide_steps.length + ' time(s) — see Inspector › Step-Through');
+                            } else {
+                                logToConsole('[breakpoints] code finished without reaching any breakpoint');
+                            }
+                        }
+                    } catch (e) { console.error('Bp epilogue failed:', e); }
+                }
+                // Inspector: snapshot Pyodide globals for the Variables tab
+                try {
+                    const skip = new Set(['__name__', '__doc__', '__package__', '__loader__', '__spec__', '__builtins__',
+                                          'img_str', 'audio_sav_arr', 'audio_sav_sr', 'PYODIDE_COUT',
+                                          'save_figure_js', 'save_audio_js', 'pyodide_print', 'io', 'base64']);
+                    const out = {};
+                    const keys = pyodide.globals.toJs().keys ? Array.from(pyodide.globals.toJs().keys()) : [];
+                    for (const k of keys) {
+                        if (skip.has(k) || (k.startsWith('__') && k.endsWith('__'))) continue;
+                        if (k.startsWith('_webide')) continue;  // trace-mode internals
+                        try {
+                            const v = pyodide.globals.get(k);
+                            const tname = (v && v.constructor && v.constructor.name) || typeof v;
+                            let strVal;
+                            try { strVal = String(v); } catch (e) { strVal = '<unrepresentable>'; }
+                            if (strVal && strVal.length > 200) strVal = strVal.slice(0, 200) + '...';
+                            out[k] = { type: tname, value: strVal };
+                            if (typeof v === 'object' && v && typeof v.destroy === 'function') v.destroy();
+                        } catch (e) { /* skip */ }
+                    }
+                    window.__webide_vars = out;
+                } catch (e) { /* ignore */ }
                 imgStr = pyodide.globals.get("img_str");
                 if (imgStr.length > 0) displayImage(imgStr, true);
                 audioStr = "";
@@ -3226,6 +5871,17 @@ def pyodide_print(s):
                 {% elsif page.language == "prolog" %}
                 let Prolog, Module;
                 var options = { arguments: [], on_output: logToConsole };
+                // Trace-on-hit for Prolog: emit one synthetic hit per
+                // breakpoint line at run-start. Prolog's clause structure
+                // doesn't accept mid-clause JS callbacks, so we surface
+                // breakpoint lines as "would-pause-here" markers in the
+                // Inspector. (Brython has the same limitation in pause-mode.)
+                try {
+                    const _bpLines = window.__webide_activeBreakpointLines() || [];
+                    for (const ln of _bpLines) {
+                        try { window.__webide_bp(ln, { lang: 'prolog' }); } catch (e) {}
+                    }
+                } catch (e) {}
                 SWIPL(options).then(async module => {
                     Module = module; Prolog = Module.prolog;
                     await Prolog.load_scripts();
@@ -3262,6 +5918,17 @@ def pyodide_print(s):
                 });
 
                 {% elsif page.language == "java" %}
+                // Trace-on-hit for Java/Processing: emit synthetic hits before
+                // Processing.js transpiles. The Java-as-JS pipeline mangles
+                // student line numbers, so we report breakpoints from the
+                // pre-transpile source rather than trying to thread callbacks
+                // through the generated JS.
+                try {
+                    const _bpLines = window.__webide_activeBreakpointLines() || [];
+                    for (const ln of _bpLines) {
+                        try { window.__webide_bp(ln, { lang: 'java' }); } catch (e) {}
+                    }
+                } catch (e) {}
                 let code = makeCodeJavaProcessing(editorText, mainText);
                 console.feedbackString = null;
                 instance = new Processing(canvas, code);
@@ -3273,6 +5940,15 @@ def pyodide_print(s):
                 function feedbackPrintlnJSConsole(s) { logToConsole(s); return s + "\n"; }
                 let code = editorText + "\n\n" + mainText;
                 code = code.replace(/console.log/g, "feedbackString += feedbackPrintlnJSConsole");
+                // Trace-on-hit: rewrite breakpoint lines to invoke __webide_bp.
+                // The instrumenter is a no-op when there are no breakpoints,
+                // so this is safe to always-on.
+                try {
+                    const _bpLines = window.__webide_activeBreakpointLines();
+                    if (_bpLines && _bpLines.length) {
+                        code = window.webideInstrumentForBreakpoints(code, 'javascript', _bpLines);
+                    }
+                } catch (e) { /* never let the helper kill the run */ }
                 eval(code);
                 {% endif %}
 
@@ -3299,6 +5975,402 @@ def pyodide_print(s):
             runtime.resetText();
             runtime.process.worker.postMessage({ function: 'run', wasmBinary: clangOutput });
         }
+
+        // -- Run history ------------------------------------------------------
+        // On every Run, snapshot { ts, files[], outcome, message } to
+        // localStorage (keyed per exercise). Last 20 entries kept; older
+        // ones discarded FIFO. A menu item opens a modal listing them and
+        // letting students restore a snapshot back into a new tab.
+        const RUN_HISTORY_KEY = 'webide.runHistory';
+        const RUN_HISTORY_CAP = 20;
+        function _runHistoryExId() {
+            try { return location.pathname || '/'; } catch (e) { return '/'; }
+        }
+        function _getRunHistory() {
+            try {
+                const all = JSON.parse(localStorage.getItem(RUN_HISTORY_KEY) || '{}');
+                return all[_runHistoryExId()] || [];
+            } catch (e) { return []; }
+        }
+        function _setRunHistory(entries) {
+            try {
+                const all = JSON.parse(localStorage.getItem(RUN_HISTORY_KEY) || '{}');
+                all[_runHistoryExId()] = entries;
+                localStorage.setItem(RUN_HISTORY_KEY, JSON.stringify(all));
+            } catch (e) { /* quota — silently drop */ }
+        }
+        async function recordRunSnapshot() {
+            try {
+                const files = await getAllFilesRecursively(rootBasePath);
+                const slim = files
+                    .filter(f => !f.excludeFromExport)
+                    .map(f => ({ path: f.path, content: typeof f.content === 'string' ? f.content : '' }));
+                const entry = {
+                    ts: Date.now(),
+                    files: slim,
+                    outcome: window.__webide_lastRunOutcome || 'unknown',
+                    message: window.__webide_lastRunMessage || '',
+                };
+                let entries = _getRunHistory();
+                entries.push(entry);
+                if (entries.length > RUN_HISTORY_CAP) {
+                    entries = entries.slice(-RUN_HISTORY_CAP);
+                }
+                _setRunHistory(entries);
+            } catch (e) { /* never break Run on history failure */ }
+        }
+        window.recordRunSnapshot = recordRunSnapshot;
+        window.menuShowRunHistory = () => {
+            const entries = _getRunHistory();
+            const dialog = document.getElementById('run-history-dialog');
+            const list   = document.getElementById('run-history-list');
+            if (!dialog || !list) return;
+            if (!entries.length) {
+                list.innerHTML = '<div style="padding:20px; text-align:center; opacity:0.7;">No run history yet.</div>';
+            } else {
+                list.innerHTML = entries.slice().reverse().map((e, i) => {
+                    const realIdx = entries.length - 1 - i;
+                    const date = new Date(e.ts);
+                    const time = date.toLocaleTimeString();
+                    const icon = e.outcome === 'pass' ? '✓' : e.outcome === 'fail' ? '✗' : e.outcome === 'error' ? '!' : '○';
+                    const color = e.outcome === 'pass' ? '#3fb950' : e.outcome === 'fail' ? '#f85149' : e.outcome === 'error' ? '#f85149' : '#a0a0a0';
+                    const fileCount = (e.files || []).length;
+                    return '<div class="run-history-item" style="display:flex; gap:8px; padding:6px 8px; border-bottom:1px solid rgba(255,255,255,0.06); align-items:center;">'
+                        + '<span style="color:' + color + '; font-weight:700; width:14px;">' + icon + '</span>'
+                        + '<span style="font-family:Consolas,monospace; font-size:11px; opacity:0.8;">' + time + '</span>'
+                        + '<span style="flex:1; font-size:11px; opacity:0.7;">' + fileCount + ' file' + (fileCount === 1 ? '' : 's') + '</span>'
+                        + '<button class="action-btn" type="button" data-restore-idx="' + realIdx + '"'
+                        + '  style="padding:2px 10px; font-size:11px;">Restore</button>'
+                        + '</div>';
+                }).join('');
+                list.querySelectorAll('button[data-restore-idx]').forEach(btn => {
+                    btn.addEventListener('click', () => {
+                        const idx = parseInt(btn.getAttribute('data-restore-idx'), 10);
+                        const entry = entries[idx];
+                        if (entry) _restoreRunSnapshot(entry);
+                    });
+                });
+            }
+            dialog.classList.add('visible');
+            dialog.setAttribute('aria-hidden', 'false');
+        };
+        function _restoreRunSnapshot(entry) {
+            // Open every file as a new "restored:HH:MM:SS" tab so the live
+            // work isn't overwritten. We can't easily re-save into IndexedDB
+            // without conflicting; show as virtual tabs only.
+            const stamp = new Date(entry.ts).toLocaleTimeString();
+            for (const f of (entry.files || [])) {
+                const virtPath = f.path + ' (restored:' + stamp + ')';
+                if (openFiles[virtPath]) continue;
+                openFiles[virtPath] = { content: f.content, modified: false, readOnly: true };
+                createTab(virtPath, f.path.split('/').pop() + ' (restored:' + stamp + ')');
+            }
+            const dialog = document.getElementById('run-history-dialog');
+            if (dialog) { dialog.classList.remove('visible'); dialog.setAttribute('aria-hidden', 'true'); }
+            if (typeof ideNotify === 'function') ideNotify('Restored ' + (entry.files || []).length + ' file(s) from ' + stamp);
+        }
+
+        // -- Submission preflight --------------------------------------------
+        // Wraps the existing postCode() with a checklist modal. The student
+        // confirms (or overrides) before their work is uploaded.
+        window._origPostCode = null;
+        function _installPreflight() {
+            if (typeof postCode !== 'function' || window._origPostCode) return;
+            window._origPostCode = postCode;
+            window.postCode = async function(halfcredit, downloadblob, points) {
+                const issues = [];
+                // Check 1: tests panel — run them silently and collect failures
+                if ((window.WEBIDE_TESTS || []).length) {
+                    try { await window.runAllTests(); } catch (e) {}
+                    const failed = Array.from(document.querySelectorAll('.test-row.fail, .test-row.error'));
+                    if (failed.length) {
+                        issues.push(failed.length + ' test(s) are failing.');
+                    }
+                }
+                // Check 2: debug prints — scan editor for stray console.log/print
+                try {
+                    const code = window.ace_editor ? window.ace_editor.getValue() : '';
+                    const dlogs = (code.match(/console\.log\(/g) || []).length;
+                    const prints = (code.match(/^\s*print\(/gm) || []).length;
+                    if (dlogs > 5) issues.push('Many console.log calls (' + dlogs + ') — clean these up?');
+                    if (prints > 10) issues.push('Many print() calls (' + prints + ') — leftover debug output?');
+                } catch (e) {}
+                // Check 3: unsaved tabs
+                const unsaved = Object.values(openFiles).filter(f => f && f.modified).length;
+                if (unsaved) issues.push(unsaved + ' tab(s) have unsaved changes.');
+
+                if (!issues.length) {
+                    return window._origPostCode(halfcredit, downloadblob, points);
+                }
+                // Show the preflight modal
+                const ok = await _showPreflightModal(issues);
+                if (ok) return window._origPostCode(halfcredit, downloadblob, points);
+            };
+        }
+        function _showPreflightModal(issues) {
+            return new Promise(resolve => {
+                const dialog = document.getElementById('preflight-dialog');
+                const body   = document.getElementById('preflight-body');
+                const okBtn  = document.getElementById('preflight-submit');
+                const cancel = document.getElementById('preflight-cancel');
+                if (!dialog || !body || !okBtn || !cancel) { resolve(true); return; }
+                body.innerHTML = '<p>Heads up before submitting:</p><ul style="padding-left:20px;">'
+                    + issues.map(i => '<li>' + i + '</li>').join('') + '</ul>';
+                dialog.classList.add('visible');
+                dialog.setAttribute('aria-hidden', 'false');
+                const onOk = () => { close(); resolve(true);  };
+                const onNo = () => { close(); resolve(false); };
+                function close() {
+                    dialog.classList.remove('visible');
+                    dialog.setAttribute('aria-hidden', 'true');
+                    okBtn.removeEventListener('click', onOk);
+                    cancel.removeEventListener('click', onNo);
+                }
+                okBtn.addEventListener('click', onOk);
+                cancel.addEventListener('click', onNo);
+            });
+        }
+        // Install at idle — postCode is defined later in this script block.
+        setTimeout(() => { try { _installPreflight(); } catch (e) {} }, 50);
+
+        // -- Hint ladder ------------------------------------------------------
+        // Instructor-authored hints unlock progressively as the student fails
+        // runs. Stored as a sorted list of {after, text}: a hint is visible
+        // once numAttempts >= after.
+        window.WEBIDE_HINTS = [
+            {% if page.processor.hints %}
+            {% for h in page.processor.hints %}
+            { after: {{ h.after | default: 1 }}, text: {{ h.text | jsonify }} }{% unless forloop.last %},{% endunless %}
+            {% endfor %}
+            {% endif %}
+        ];
+        const HINTS_KEY = 'webide.hintCounts';
+        function _hintExerciseId() {
+            // Use the page URL path as the per-exercise key. Stable across reloads.
+            try { return location.pathname || '/'; } catch (e) { return '/'; }
+        }
+        function _getHintAttempts() {
+            try {
+                const m = JSON.parse(localStorage.getItem(HINTS_KEY) || '{}');
+                return m[_hintExerciseId()] | 0;
+            } catch (e) { return 0; }
+        }
+        function _setHintAttempts(n) {
+            try {
+                const m = JSON.parse(localStorage.getItem(HINTS_KEY) || '{}');
+                m[_hintExerciseId()] = n;
+                localStorage.setItem(HINTS_KEY, JSON.stringify(m));
+            } catch (e) {}
+        }
+        function _renderHintLadder() {
+            const wrap = document.getElementById('hint-ladder');
+            const list = document.getElementById('hint-ladder-list');
+            if (!wrap || !list) return;
+            const hints = (window.WEBIDE_HINTS || []).slice().sort((a, b) => (a.after | 0) - (b.after | 0));
+            if (!hints.length) { wrap.hidden = true; return; }
+            const attempts = _getHintAttempts();
+            const unlocked = hints.filter(h => attempts >= (h.after | 0));
+            if (!unlocked.length) {
+                wrap.hidden = false;
+                list.innerHTML = '<p style="opacity:0.7;">Hints will appear here as you make attempts. ('
+                    + attempts + ' so far; next at attempt ' + hints[0].after + ').</p>';
+                return;
+            }
+            wrap.hidden = false;
+            list.innerHTML = unlocked.map((h, i) =>
+                '<details ' + (i === unlocked.length - 1 ? 'open' : '') + ' style="margin:4px 0;">'
+                + '<summary style="cursor:pointer; color:#ce9178;">Hint ' + (i + 1) + ' (unlocked after attempt ' + h.after + ')</summary>'
+                + '<div style="padding:4px 0 4px 12px;">' + h.text + '</div>'
+                + '</details>'
+            ).join('');
+        }
+        window.refreshHintLadder = _renderHintLadder;
+
+        // -- Tests panel ------------------------------------------------------
+        // Front-matter schema (under page.processor.tests) shape:
+        //   - name: "factorial(0) == 1"
+        //     code: "assert fact(0) == 1"
+        //     expect: { throws: false }
+        //
+        // Runs each test against the student source by appending the test
+        // body to the student source and evaluating it in the same runtime.
+        // Captures stdout, return value, and any thrown exception, then
+        // matches against the expect spec.
+        window.WEBIDE_TESTS = [
+            {% if page.processor.tests %}
+            {% for t in page.processor.tests %}
+            {
+                name: {{ t.name | jsonify }},
+                code: {{ t.code | jsonify }},
+                expect: {% if t.expect %}{{ t.expect | jsonify }}{% else %}{}{% endif %}
+            }{% unless forloop.last %},{% endunless %}
+            {% endfor %}
+            {% endif %}
+        ];
+
+        function _testIconFor(status) {
+            // Shape-distinguishable glyphs so color-blind mode reads right
+            switch (status) {
+                case 'pass':    return '✓';
+                case 'fail':    return '✗';
+                case 'error':   return '!';
+                case 'pending': return '○';
+                default:        return '?';
+            }
+        }
+
+        // Initialize the Tests panel — fills the count badge, replaces the
+        // empty-state with a pending row per test (or leaves the empty
+        // message if WEBIDE_TESTS is empty).
+        function _initTestsPanel() {
+            const body  = document.getElementById('tests-body');
+            const count = document.getElementById('tests-count');
+            const sum   = document.getElementById('tests-summary');
+            if (!body) return;
+            const tests = window.WEBIDE_TESTS || [];
+            if (count) count.textContent = tests.length ? '(' + tests.length + ')' : '';
+            if (sum)   sum.textContent   = tests.length ? '0 / ' + tests.length + ' run' : '';
+            if (!tests.length) return;
+            body.innerHTML = '';
+            tests.forEach((t, idx) => {
+                const row = document.createElement('div');
+                row.className = 'test-row pending';
+                row.id = '_test_row_' + idx;
+                row.innerHTML = '<span class="test-icon" aria-hidden="true">○</span>' +
+                                '<span class="test-name"></span>';
+                row.querySelector('.test-name').textContent = t.name;
+                body.appendChild(row);
+            });
+        }
+
+        function _setTestStatus(idx, status, detail) {
+            const row = document.getElementById('_test_row_' + idx);
+            if (!row) return;
+            row.className = 'test-row ' + status;
+            const icon = row.querySelector('.test-icon');
+            if (icon) icon.textContent = _testIconFor(status);
+            // Remove any prior detail block
+            const prev = row.parentElement.querySelector('#_test_detail_' + idx);
+            if (prev) prev.remove();
+            if (detail) {
+                const det = document.createElement('div');
+                det.className = 'test-detail';
+                det.id = '_test_detail_' + idx;
+                det.textContent = detail;
+                row.parentElement.insertBefore(det, row.nextSibling);
+            }
+        }
+
+        function _updateTestsSummary(passed, total) {
+            const sum = document.getElementById('tests-summary');
+            if (!sum) return;
+            const failed = total - passed;
+            sum.textContent = passed + ' / ' + total + ' passing' + (failed ? ' (' + failed + ' failed)' : '');
+            sum.style.color = failed ? '#f85149' : (passed ? '#3fb950' : 'inherit');
+        }
+
+        // Evaluate one test against the student source. The runtime varies
+        // per page.language; we centralize the dispatch here so the Tests
+        // panel is one block of code rather than four.
+        async function _runOneTest(studentSrc, t) {
+            const expect = t.expect || {};
+            let stdout = '', threw = null, returned = undefined;
+            const composed = studentSrc + '\n' + t.code + '\n';
+            const lang = (window._PAGE_LANG || '').toLowerCase();
+            try {
+                if (lang === 'javascript' || lang === 'graphics_view' || lang === 'graphics_shader') {
+                    // Capture console.log into stdout, then eval at module scope
+                    const _origLog = console.log;
+                    console.log = (...args) => { stdout += args.map(String).join(' ') + '\n'; };
+                    try {
+                        returned = (new Function('return (' + composed + '\n)'))();
+                    } catch (firstErr) {
+                        try { (new Function(composed))(); }
+                        catch (e2) { threw = e2; }
+                    } finally {
+                        console.log = _origLog;
+                    }
+                } else if (lang === 'python') {
+                    // Brython
+                    if (typeof window.run_python_code === 'function') {
+                        try { stdout = window.run_python_code(composed); }
+                        catch (e) { threw = e; }
+                    } else { threw = new Error('Brython not loaded'); }
+                } else if (lang === 'pyodide') {
+                    if (!window.pyodide) { threw = new Error('Pyodide not loaded'); }
+                    else {
+                        try {
+                            window.pyodide.runPython('PYODIDE_COUT = ""');
+                            window.pyodide.runPython(composed);
+                            stdout = window.pyodide.globals.get('PYODIDE_COUT') || '';
+                        } catch (e) { threw = e; }
+                    }
+                } else if (lang === 'sql') {
+                    if (typeof doSql === 'function') {
+                        try { stdout = await doSql('', composed); }
+                        catch (e) { threw = e; }
+                    } else { threw = new Error('SQL runtime not loaded'); }
+                } else if (lang === 'scheme') {
+                    if (typeof doScheme === 'function') {
+                        try { returned = await doScheme('', composed); }
+                        catch (e) { threw = e; }
+                    } else { threw = new Error('Scheme runtime not loaded'); }
+                } else {
+                    return { status: 'error', detail: 'Tests not yet supported for language: ' + lang };
+                }
+            } catch (e) {
+                threw = e;
+            }
+            // Match expect spec
+            if (expect.throws === true)  return threw ? { status: 'pass' } : { status: 'fail', detail: 'expected to throw, did not' };
+            if (expect.throws === false) {
+                if (threw) return { status: 'fail', detail: 'unexpectedly threw: ' + (threw.message || String(threw)) };
+            }
+            if (typeof expect.stdout === 'string') {
+                try {
+                    const re = new RegExp(expect.stdout);
+                    if (!re.test(stdout)) return { status: 'fail', detail: 'stdout did not match /' + expect.stdout + '/\n--- got ---\n' + stdout };
+                } catch (e) { return { status: 'error', detail: 'bad regex in expect.stdout: ' + e.message }; }
+            }
+            if (expect.returns !== undefined) {
+                if (JSON.stringify(returned) !== JSON.stringify(expect.returns)) {
+                    return { status: 'fail', detail: 'expected returns=' + JSON.stringify(expect.returns) + ', got ' + JSON.stringify(returned) };
+                }
+            }
+            if (expect.vars && typeof expect.vars === 'object') {
+                const actual = window.__webide_vars || {};
+                for (const k of Object.keys(expect.vars)) {
+                    const a = actual[k];
+                    const want = expect.vars[k];
+                    if (!a || String(a.value) !== String(want)) {
+                        return { status: 'fail', detail: 'expected ' + k + '=' + want + ', got ' + (a ? a.value : '<missing>') };
+                    }
+                }
+            }
+            return { status: 'pass' };
+        }
+
+        async function runAllTests() {
+            const tests = window.WEBIDE_TESTS || [];
+            if (!tests.length) return;
+            switchBottomTab('tests');
+            saveActiveTabs();
+            let editorText = '', mainText = '';
+            try {
+                editorText = await getCodeText();
+                mainText   = await getMainCodeText();
+            } catch (e) {}
+            const studentSrc = editorText + '\n\n' + mainText;
+            let passed = 0;
+            for (let i = 0; i < tests.length; i++) {
+                _setTestStatus(i, 'pending');
+                const r = await _runOneTest(studentSrc, tests[i]);
+                _setTestStatus(i, r.status, r.detail);
+                if (r.status === 'pass') passed++;
+                _updateTestsSummary(passed, tests.length);
+            }
+        }
+        window.runAllTests = runAllTests;
 
         async function checkAnswer() {
             console.log("Got feedback string: " + feedbackString);
@@ -4767,6 +7839,14 @@ def pyodide_print(s):
                 if ((e.ctrlKey || e.metaKey) && e.key === 'b') { e.preventDefault(); menuToggleSidebar(); }
                 if ((e.ctrlKey || e.metaKey) && e.key === '`') { e.preventDefault(); menuToggleTerminal(); }
                 if (e.altKey && e.key === 'z') { e.preventDefault(); menuToggleWordWrap(); }
+                if (e.key === 'F9' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+                    e.preventDefault();
+                    window.toggleBreakpointAtCursor();
+                }
+                if (e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey && (e.key === 't' || e.key === 'T')) {
+                    e.preventDefault();
+                    if (typeof runAllTests === 'function') runAllTests();
+                }
             });
         }
 

--- a/exercise.html
+++ b/exercise.html
@@ -3040,6 +3040,22 @@ del _webide_compiled, _webide_student_source
                       message: 'Remember to close Scanner to avoid resource leaks',
                       suggestion: 'Use try-with-resources: try (Scanner sc = new Scanner(...))',
                       severity: 'info' },
+                    // -- CS173 Style Guide rules ------------------------------------
+                    { re: /==\s*(?:true|false)\b|\b(?:true|false)\s*==/,
+                      message: 'CS173: Do not compare booleans to true or false with ==',
+                      suggestion: 'Use the variable directly: if (isValid) not if (isValid == true)', severity: 'info' },
+                    { re: /\bboolean\s+(?:\w*[Nn]ot[A-Z]\w*|\w+[Cc]heck\b|\w+[Ff]lag\b|[Cc]heck[A-Z]\w*|[Nn]ot[A-Z]\w*)/,
+                      message: 'CS173: Boolean variable names should be positive (isReady, isValid, hasValue)',
+                      suggestion: 'Rename to start with "is", "has", "can", "should", or "will"', severity: 'info' },
+                    { re: /\bgoto\b/,
+                      message: 'CS173: goto is not valid Java and leads to spaghetti code',
+                      suggestion: 'Use loops, break, continue, or return to control flow instead', severity: 'error' },
+                    { re: /\bfinal\s+(?:static\s+)?(?:int|double|float|long|short|byte|char|boolean|String)\s+[a-z]\w*\s*=/,
+                      message: 'CS173: final constants should be named in ALL_CAPS_WITH_UNDERSCORES',
+                      suggestion: 'Rename to SCREAMING_SNAKE_CASE: e.g. static final int MAX_SIZE = 100', severity: 'warning' },
+                    { re: /\b(?:int|double|float|long|short|byte)\s+[a-z]\w*\s*=\s*[2-9]\d{2,}\b/,
+                      message: 'CS173: Magic number — consider naming this constant with a final variable',
+                      suggestion: 'Declare: static final int MY_CONST = value; then use MY_CONST', severity: 'info' },
                 ],
                 wholeProg(lines) {
                     const issues = [];
@@ -3139,6 +3155,91 @@ del _webide_compiled, _webide_student_source
                         }
                     }
 
+                    // -- CS173: Missing braces on single-statement bodies ------
+                    for (let i = 0; i < lines.length - 1; i++) {
+                        const ln = lines[i];
+                        if (/^\s*(?:if|else\s+if|for|while)\s*\(/.test(ln) || /^\s*else\s*$/.test(ln.trimEnd())) {
+                            if (!/\{\s*(?:\/\/.*)?$/.test(ln)) {
+                                const next = (lines[i + 1] || '').trim();
+                                if (next && next !== '{' && !next.startsWith('//') && !next.startsWith('*')) {
+                                    issues.push({ line: i + 1, severity: 'warning',
+                                        message: 'CS173: Always use { } braces even for single-line if/for/while bodies',
+                                        suggestion: 'Wrap the body: if (cond) { stmt; }' });
+                                }
+                            }
+                        }
+                    }
+
+                    // -- CS173: Long boolean conditions ------------------------
+                    for (let i = 0; i < lines.length; i++) {
+                        if (lines[i].trim().startsWith('//')) continue;
+                        const m = lines[i].match(/\b(?:if|while)\s*\((.+)/);
+                        if (m && m[1].replace(/\/\/.*$/, '').length > 80) {
+                            issues.push({ line: i + 1, severity: 'info',
+                                message: 'CS173: Long boolean condition — extract to a named boolean variable',
+                                suggestion: 'boolean isReady = <long condition>; if (isReady) { ... }' });
+                        }
+                    }
+
+                    // -- CS173: break inside a loop but not a switch ----------
+                    {
+                        const blkStack = []; // each entry: 'switch' | 'loop' | 'other'
+                        for (let i = 0; i < lines.length; i++) {
+                            const raw = lines[i];
+                            const stripped = raw.replace(/\/\/.*$/, '');
+                            let pendingType = 'other';
+                            if (/\bswitch\s*\(/.test(stripped)) pendingType = 'switch';
+                            else if (/\b(?:for|while|do)\b/.test(stripped) &&
+                                     !/^\s*(?:public|private|protected|static)\b/.test(stripped)) {
+                                pendingType = 'loop';
+                            }
+                            let firstBrace = true;
+                            for (const ch of stripped) {
+                                if (ch === '{') { blkStack.push(firstBrace ? pendingType : 'other'); firstBrace = false; }
+                                else if (ch === '}') blkStack.pop();
+                            }
+                            if (/^\s*break\s*;/.test(raw)) {
+                                let innermost = null;
+                                for (let k = blkStack.length - 1; k >= 0; k--) {
+                                    if (blkStack[k] === 'switch' || blkStack[k] === 'loop') { innermost = blkStack[k]; break; }
+                                }
+                                if (innermost === 'loop') {
+                                    issues.push({ line: i + 1, severity: 'warning',
+                                        message: 'CS173: break in loop — restructure the loop condition instead',
+                                        suggestion: 'Move the exit condition to the loop header; break should only appear in switch' });
+                                }
+                            }
+                        }
+                    }
+
+                    // -- CS173: Compound method calls (>= 3 on one line) ------
+                    for (let i = 0; i < lines.length; i++) {
+                        const t = lines[i].trim();
+                        if (t.startsWith('//') || t.startsWith('*')) continue;
+                        // Strip flow-control keywords so for/while/if parens don't count
+                        const stripped = lines[i].replace(/\b(?:if|while|for|do|switch|catch|try)\s*\(/g, ' ');
+                        const callCount = (stripped.match(/\w\s*\(/g) || []).length;
+                        if (callCount >= 3) {
+                            issues.push({ line: i + 1, severity: 'info',
+                                message: 'CS173: Avoid deeply-nested compound method calls — hard to read and debug',
+                                suggestion: 'Extract intermediate results into named variables for clarity' });
+                        }
+                    }
+
+                    // -- CS173: System.out.println used as an input prompt -----
+                    for (let i = 0; i < lines.length - 1; i++) {
+                        if (/\bSystem\.out\.println\s*\(/.test(lines[i])) {
+                            for (let j = i + 1; j <= Math.min(i + 2, lines.length - 1); j++) {
+                                if (/\.next(?:Int|Double|Float|Long|Line|Boolean|Byte|Short)?\s*\(/.test(lines[j])) {
+                                    issues.push({ line: i + 1, severity: 'info',
+                                        message: 'CS173: Use System.out.print() for input prompts so input appears on the same line',
+                                        suggestion: 'Replace println with print: System.out.print("Enter value: ")' });
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
                     return issues;
                 }
             },
@@ -3167,6 +3268,18 @@ del _webide_compiled, _webide_student_source
                     { re: /\bl\b\s*=|\bl\b[+\-*/]=|\bO\b\s*=|\bO\b[+\-*/]=/,
                       message: 'Variable named "l" or "O" is easily confused with 1 and 0',
                       suggestion: 'Choose a more descriptive variable name (PEP 8)', severity: 'info' },
+                    { re: /^\s*def\s+[A-Z]/,
+                      message: 'Function names should be lowercase_with_underscores (PEP 8)',
+                      suggestion: 'Use snake_case: def my_function()', severity: 'warning' },
+                    { re: /^\s*class\s+[a-z]/,
+                      message: 'Class names should be CamelCase (PEP 8)',
+                      suggestion: 'Capitalize: class MyClass:', severity: 'info' },
+                    { re: /==\s*(?:True|False)\b|\b(?:True|False)\s*==/,
+                      message: 'CS173: Do not compare booleans to True/False with ==',
+                      suggestion: 'Use the expression directly: if is_valid: not if is_valid == True:', severity: 'info' },
+                    { re: /\bgoto\b/,
+                      message: 'CS173: goto is not valid Python',
+                      suggestion: 'Use loops, break, continue, or return instead', severity: 'error' },
                 ],
                 wholeProg(lines) {
                     const issues = [];
@@ -3193,6 +3306,40 @@ del _webide_compiled, _webide_student_source
                                         suggestion: 'Remove or restructure' });
                                 }
                             }
+                        }
+                    }
+                    // CS173: missing docstring on function definitions
+                    for (let i = 0; i < lines.length - 1; i++) {
+                        if (/^\s*def\s+\w+/.test(lines[i])) {
+                            // Find the first non-empty line after the def (may skip multi-line signature)
+                            let j = i + 1;
+                            while (j < lines.length && (lines[j].trim() === '' || /^\s*\)/.test(lines[j]))) j++;
+                            if (j < lines.length && !/^\s*"""/.test(lines[j]) && !/^\s*'''/.test(lines[j])) {
+                                issues.push({ line: i+1, severity: 'info',
+                                    message: 'CS173: Function is missing a docstring — document parameters and return value',
+                                    suggestion: 'Add a docstring: """Summary. Args: ... Returns: ..."""' });
+                            }
+                        }
+                    }
+                    // CS173: long boolean conditions
+                    for (let i = 0; i < lines.length; i++) {
+                        if (lines[i].trim().startsWith('#')) continue;
+                        const m = lines[i].match(/\b(?:if|while)\s+(.+?):/);
+                        if (m && m[1].length > 80) {
+                            issues.push({ line: i+1, severity: 'info',
+                                message: 'CS173: Long boolean condition — extract to a named boolean variable',
+                                suggestion: 'is_ready = <long condition>\nif is_ready:' });
+                        }
+                    }
+                    // CS173: compound function calls (>= 3 call sites on one line)
+                    for (let i = 0; i < lines.length; i++) {
+                        const t = lines[i].trim();
+                        if (t.startsWith('#')) continue;
+                        const callCount = (lines[i].match(/\w\s*\(/g) || []).length;
+                        if (callCount >= 3) {
+                            issues.push({ line: i+1, severity: 'info',
+                                message: 'CS173: Avoid deeply-nested compound function calls',
+                                suggestion: 'Extract intermediate results into named variables' });
                         }
                     }
                     return issues;
@@ -3226,6 +3373,12 @@ del _webide_compiled, _webide_student_source
                     { re: /delete\s+\w+;(?!.*\[\])/,
                       message: 'Using delete — ensure this was allocated with new (not new[])',
                       suggestion: 'Use delete[] for arrays', severity: 'info' },
+                    { re: /\bgoto\b/,
+                      message: 'CS173: goto creates spaghetti code and is banned by the style guide',
+                      suggestion: 'Use loops, break, continue, or return instead', severity: 'warning' },
+                    { re: /==\s*(?:true|false)\b|\b(?:true|false)\s*==/,
+                      message: 'CS173: Do not compare booleans to true/false with ==',
+                      suggestion: 'Use the variable directly: if (isValid) not if (isValid == true)', severity: 'info' },
                 ],
                 wholeProg(lines) {
                     const issues = [];
@@ -3252,6 +3405,58 @@ del _webide_compiled, _webide_student_source
                         }
                         if (opens > closes) seenJump = false;
                     }
+                    // CS173: Missing braces on single-statement bodies
+                    for (let i = 0; i < lines.length - 1; i++) {
+                        const ln = lines[i];
+                        if (/^\s*(?:if|else\s+if|for|while)\s*\(/.test(ln) || /^\s*else\s*$/.test(ln.trimEnd())) {
+                            if (!/\{\s*(?:\/\/.*)?$/.test(ln)) {
+                                const next = (lines[i + 1] || '').trim();
+                                if (next && next !== '{' && !next.startsWith('//') && !next.startsWith('*')) {
+                                    issues.push({ line: i+1, severity: 'warning',
+                                        message: 'CS173: Always use { } braces even for single-line if/for/while bodies',
+                                        suggestion: 'Wrap the body: if (cond) { stmt; }' });
+                                }
+                            }
+                        }
+                    }
+                    // CS173: break in loop but not switch
+                    {
+                        const blkStack = [];
+                        for (let i = 0; i < lines.length; i++) {
+                            const stripped = lines[i].replace(/\/\/.*$/, '');
+                            let pendingType = 'other';
+                            if (/\bswitch\s*\(/.test(stripped)) pendingType = 'switch';
+                            else if (/\b(?:for|while|do)\b/.test(stripped)) pendingType = 'loop';
+                            let firstBrace = true;
+                            for (const ch of stripped) {
+                                if (ch === '{') { blkStack.push(firstBrace ? pendingType : 'other'); firstBrace = false; }
+                                else if (ch === '}') blkStack.pop();
+                            }
+                            if (/^\s*break\s*;/.test(lines[i])) {
+                                let innermost = null;
+                                for (let k = blkStack.length - 1; k >= 0; k--) {
+                                    if (blkStack[k] === 'switch' || blkStack[k] === 'loop') { innermost = blkStack[k]; break; }
+                                }
+                                if (innermost === 'loop') {
+                                    issues.push({ line: i+1, severity: 'warning',
+                                        message: 'CS173: break in loop — prefer restructuring the loop condition',
+                                        suggestion: 'break should only appear in switch; restructure as while(condition)' });
+                                }
+                            }
+                        }
+                    }
+                    // CS173: compound function calls (>= 3 call sites on one line)
+                    for (let i = 0; i < lines.length; i++) {
+                        const t = lines[i].trim();
+                        if (t.startsWith('//') || t.startsWith('*')) continue;
+                        const stripped = lines[i].replace(/\b(?:if|while|for|do|switch|catch|try)\s*\(/g, ' ');
+                        const callCount = (stripped.match(/\w\s*\(/g) || []).length;
+                        if (callCount >= 3) {
+                            issues.push({ line: i+1, severity: 'info',
+                                message: 'CS173: Avoid deeply-nested compound method calls',
+                                suggestion: 'Extract intermediate results into named variables' });
+                        }
+                    }
                     return issues;
                 }
             },
@@ -3277,6 +3482,12 @@ del _webide_compiled, _webide_student_source
                     { re: /==[^=].*null|null.*==[^=]/,
                       message: 'Loose null check — also matches undefined due to type coercion',
                       suggestion: 'Use === null for strict null check', severity: 'info' },
+                    { re: /===\s*(?:true|false)\b|\b(?:true|false)\s*===/,
+                      message: 'CS173: Do not compare booleans to true/false with ===',
+                      suggestion: 'Use the expression directly or negate with !', severity: 'info' },
+                    { re: /\bgoto\b/,
+                      message: 'CS173: goto is not valid JavaScript (label:goto syntax aside)',
+                      suggestion: 'Use break <label>, continue, or return instead', severity: 'error' },
                 ],
                 wholeProg(lines) {
                     const issues = [];
@@ -3297,6 +3508,58 @@ del _webide_compiled, _webide_student_source
                         braceDepth += opens - closes;
                         if (/^\s*return\b/.test(trim)) { seenReturn = true; returnDepth = braceDepth; }
                         if (opens > closes) seenReturn = false;
+                    }
+                    // CS173: Missing braces on single-statement bodies
+                    for (let i = 0; i < lines.length - 1; i++) {
+                        const ln = lines[i];
+                        if (/^\s*(?:if|else\s+if|for|while)\s*\(/.test(ln) || /^\s*else\s*$/.test(ln.trimEnd())) {
+                            if (!/\{\s*(?:\/\/.*)?$/.test(ln)) {
+                                const next = (lines[i + 1] || '').trim();
+                                if (next && next !== '{' && !next.startsWith('//')) {
+                                    issues.push({ line: i+1, severity: 'warning',
+                                        message: 'CS173: Always use { } braces even for single-line if/for/while bodies',
+                                        suggestion: 'Wrap the body: if (cond) { stmt; }' });
+                                }
+                            }
+                        }
+                    }
+                    // CS173: break in loop but not switch
+                    {
+                        const blkStack = [];
+                        for (let i = 0; i < lines.length; i++) {
+                            const stripped = lines[i].replace(/\/\/.*$/, '');
+                            let pendingType = 'other';
+                            if (/\bswitch\s*\(/.test(stripped)) pendingType = 'switch';
+                            else if (/\b(?:for|while|do)\b/.test(stripped)) pendingType = 'loop';
+                            let firstBrace = true;
+                            for (const ch of stripped) {
+                                if (ch === '{') { blkStack.push(firstBrace ? pendingType : 'other'); firstBrace = false; }
+                                else if (ch === '}') blkStack.pop();
+                            }
+                            if (/^\s*break\s*;/.test(lines[i])) {
+                                let innermost = null;
+                                for (let k = blkStack.length - 1; k >= 0; k--) {
+                                    if (blkStack[k] === 'switch' || blkStack[k] === 'loop') { innermost = blkStack[k]; break; }
+                                }
+                                if (innermost === 'loop') {
+                                    issues.push({ line: i+1, severity: 'warning',
+                                        message: 'CS173: break in loop — prefer restructuring the loop condition',
+                                        suggestion: 'break should only appear in switch; restructure as while(condition)' });
+                                }
+                            }
+                        }
+                    }
+                    // CS173: compound function calls (>= 3 call sites on one line)
+                    for (let i = 0; i < lines.length; i++) {
+                        const t = lines[i].trim();
+                        if (t.startsWith('//')) continue;
+                        const stripped = lines[i].replace(/\b(?:if|while|for|do|switch|catch)\s*\(/g, ' ');
+                        const callCount = (stripped.match(/\w\s*\(/g) || []).length;
+                        if (callCount >= 3) {
+                            issues.push({ line: i+1, severity: 'info',
+                                message: 'CS173: Avoid deeply-nested compound function calls',
+                                suggestion: 'Extract intermediate results into named variables' });
+                        }
                     }
                     return issues;
                 }
@@ -3320,8 +3583,25 @@ del _webide_compiled, _webide_student_source
                     { re: /DROP\s+(TABLE|DATABASE)\b/i,
                       message: 'DROP statement is irreversible',
                       suggestion: 'Ensure this is intentional', severity: 'warning' },
+                    { re: /\bHAVING\b/i,
+                      message: 'HAVING filters aggregated groups — ensure GROUP BY is also present',
+                      suggestion: 'Add GROUP BY before HAVING', severity: 'info' },
+                    { re: /\bSELECT\b(?![^;]*\bFROM\b)/i,
+                      message: 'SELECT without FROM — did you mean to select from a table?',
+                      suggestion: 'Add a FROM clause: SELECT col FROM table', severity: 'warning' },
                 ],
-                wholeProg(lines) { return []; }
+                wholeProg(lines) {
+                    const issues = [];
+                    // HAVING without GROUP BY (whole-program check)
+                    const src = lines.join('\n').toUpperCase();
+                    if (/\bHAVING\b/.test(src) && !/\bGROUP\s+BY\b/.test(src)) {
+                        const havingLine = lines.findIndex(l => /\bHAVING\b/i.test(l));
+                        issues.push({ line: havingLine + 1, severity: 'warning',
+                            message: 'HAVING clause requires GROUP BY — without it, HAVING filters all rows as one group',
+                            suggestion: 'Add GROUP BY <column> before the HAVING clause' });
+                    }
+                    return issues;
+                }
             },
 
             // -- Scheme --------------------------------------------------------
@@ -3333,6 +3613,12 @@ del _webide_compiled, _webide_student_source
                     { re: /\(eq\?\s+[^)]*"[^"]*"/,
                       message: '"eq?" compares identity, not string content',
                       suggestion: 'Use (equal? ...) or (string=? ...) for string comparison', severity: 'warning' },
+                    { re: /\(define\s+\([^)]+\)/,
+                      message: 'CS173: Document this function with a comment describing its purpose and arguments',
+                      suggestion: 'Add a comment above: ; name: summary of what it does', severity: 'info' },
+                    { re: /c[ad]{4,}r\s*\(/,
+                      message: 'Deep car/cdr composition (caar/cadr etc.) can be hard to read',
+                      suggestion: 'Use named let or intermediate bindings for clarity', severity: 'info' },
                 ],
                 wholeProg(lines) {
                     const issues = [];
@@ -3358,6 +3644,43 @@ del _webide_compiled, _webide_student_source
                     }
                     return issues;
                 }
+            },
+
+            // -- Prolog --------------------------------------------------------
+            prolog: {
+                perLinePat: [
+                    { re: /^\s*[a-z][a-zA-Z_]*\s*:-/,
+                      message: 'Prolog rule head looks correct — ensure clause variables start with uppercase',
+                      suggestion: 'Variables in Prolog must start with uppercase or _: X, MyVar, _Unused', severity: 'info' },
+                    { re: /\basserta\s*\(|assertz\s*\(/,
+                      message: 'Dynamic assert modifies the knowledge base at runtime — use with care',
+                      suggestion: 'Prefer static facts/rules where possible; use assert only when state must change', severity: 'info' },
+                    { re: /!\s*(?:,|\.)/, // cut followed by comma or period
+                      message: 'Cut (!) restricts backtracking — ensure this is intentional',
+                      suggestion: 'Document why the cut is needed; it prevents alternative solutions', severity: 'info' },
+                ],
+                wholeProg(lines) {
+                    const issues = [];
+                    // Check for singleton variables (Prolog convention: prefix with _ if intentionally unused)
+                    const varPat = /\b([A-Z][a-zA-Z0-9_]*)\b/g;
+                    const counts = {};
+                    for (const line of lines) {
+                        const stripped = line.replace(/%.*$/, ''); // strip comments
+                        let m;
+                        while ((m = varPat.exec(stripped)) !== null) {
+                            const v = m[1];
+                            if (v !== '_') counts[v] = (counts[v] || 0) + 1;
+                        }
+                    }
+                    // Warn on variables that appear exactly once (singleton)
+                    const singletons = Object.entries(counts).filter(([,n]) => n === 1).map(([v]) => v);
+                    if (singletons.length > 0) {
+                        issues.push({ line: 1, severity: 'info',
+                            message: `Possible singleton variable(s): ${singletons.slice(0,5).join(', ')} — if unused, prefix with _`,
+                            suggestion: 'Use _VarName to indicate intentionally unused variables in Prolog' });
+                    }
+                    return issues;
+                }
             }
         };
 
@@ -3366,6 +3689,8 @@ del _webide_compiled, _webide_student_source
         // Alias graphics languages to javascript
         _analysisRules.graphics_view    = _analysisRules.javascript;
         _analysisRules.graphics_shader  = _analysisRules.javascript;
+        // Alias processing/java to java
+        _analysisRules.processing       = _analysisRules.java;
 
         function analyzeCode(language, code) {
             const ruleset = _analysisRules[language];

--- a/exercise.html
+++ b/exercise.html
@@ -2130,10 +2130,22 @@ del _webide_compiled, _webide_student_source
         const projectName = `{{page.canvasasmtid}}`;
         let rootBasePath = `/${user}/${projectName}`;
         let openFiles = {};
+        // Expose for tests / extensions (parallels window.ace_editor).
+        // The let-binding is the source of truth; this is a Proxy mirror
+        // so window-side reads/writes affect the same object.
+        try { Object.defineProperty(window, 'openFiles', { get: () => openFiles, set: v => { openFiles = v; }, configurable: true }); } catch (e) {}
         const publicKey = `{% if layout.publickey %}{{ layout.publickey }}{% else %}{{ site.publickey }}{% endif %}`;
         let numAttempts = 0;
         let correctlyAnswered = false;
+        // Expose for tests / extensions (parallels window.openFiles).
+        try {
+            Object.defineProperty(window, 'numAttempts', { get: () => numAttempts, set: v => { numAttempts = v; }, configurable: true });
+            Object.defineProperty(window, 'correctlyAnswered', { get: () => correctlyAnswered, set: v => { correctlyAnswered = v; }, configurable: true });
+        } catch (e) {}
         let feedbackString = "";
+        try {
+            Object.defineProperty(window, 'feedbackString', { get: () => feedbackString, set: v => { feedbackString = v; }, configurable: true });
+        } catch (e) {}
 
         const initialFiles = [
             {% for file in page.files %}
@@ -2568,6 +2580,9 @@ del _webide_compiled, _webide_student_source
             fileNames.forEach(fileName => openFile(`${rootBasePath}/${fileName}`, fileName));
         }
 
+        // Exposed for tests / extensions.
+        window.setActiveTab = setActiveTab;
+        window.saveActiveTabs = () => saveActiveTabs();
         async function setActiveTab(path) {
             // ARIA tab pattern: roving tabindex + aria-selected
             document.querySelectorAll('.tab').forEach(t => {
@@ -5448,11 +5463,28 @@ del _webide_compiled, _webide_student_source
                 '#ifndef _STDIO_H\n' +
                 '#define _STDIO_H\n' +
                 '#endif\n' +
+                // NULL must be assignable to typed pointers in C++; (void*)0
+                // is C-only. Use compiler-builtin null sentinel in C++.
                 '#ifndef NULL\n' +
+                '#ifdef __cplusplus\n' +
+                '#define NULL 0\n' +
+                '#else\n' +
                 '#define NULL ((void*)0)\n' +
                 '#endif\n' +
-                'typedef unsigned long size_t;\n' +
+                '#endif\n' +
+                // size_t is wasm32 = unsigned int (NOT unsigned long); use
+                // compiler-builtin __SIZE_TYPE__ which is always correct.
+                // Also guard so musl/libcxx headers don\'t redefine it.
+                '#ifndef _SIZE_T_DECLARED\n' +
+                '#define _SIZE_T_DECLARED\n' +
+                'typedef __SIZE_TYPE__ size_t;\n' +
+                '#endif\n' +
+                // EOF — libcxx <string> uses it in char_traits::eof().
+                '#ifndef EOF\n' +
+                '#define EOF (-1)\n' +
+                '#endif\n' +
                 'typedef struct _IO_FILE FILE;\n' +
+                'typedef long fpos_t;\n' +
                 'extern FILE *stdin, *stdout, *stderr;\n' +
                 '#ifdef __cplusplus\n' +
                 'extern "C" {\n' +
@@ -5474,6 +5506,37 @@ del _webide_compiled, _webide_student_source
                 'size_t fwrite(const void *, size_t, size_t, FILE *);\n' +
                 'int feof(FILE *);\n' +
                 'char *fgets(char *, int, FILE *);\n' +
+                // Extras that libcxx <cstdio> imports via `using ::tmpnam`
+                // etc. Declarations only — linking still uses the runtime\'s
+                // real implementations.
+                'char *tmpnam(char *);\n' +
+                'int vprintf(const char *, void *);\n' +
+                'int vfprintf(FILE *, const char *, void *);\n' +
+                'int vsprintf(char *, const char *, void *);\n' +
+                'int vsnprintf(char *, size_t, const char *, void *);\n' +
+                'int vscanf(const char *, void *);\n' +
+                'int vfscanf(FILE *, const char *, void *);\n' +
+                'int vsscanf(const char *, const char *, void *);\n' +
+                'int remove(const char *);\n' +
+                'int rename(const char *, const char *);\n' +
+                'int ferror(FILE *);\n' +
+                'void clearerr(FILE *);\n' +
+                'long ftell(FILE *);\n' +
+                'int fseek(FILE *, long, int);\n' +
+                'void rewind(FILE *);\n' +
+                'void perror(const char *);\n' +
+                'int ungetc(int, FILE *);\n' +
+                'int fgetc(FILE *);\n' +
+                'int fputc(int, FILE *);\n' +
+                'int fputs(const char *, FILE *);\n' +
+                'FILE *tmpfile(void);\n' +
+                'void setbuf(FILE *, char *);\n' +
+                'int setvbuf(FILE *, char *, int, size_t);\n' +
+                'int fgetpos(FILE *, void *);\n' +
+                'int fsetpos(FILE *, const void *);\n' +
+                'int putc(int, FILE *);\n' +
+                'int getc(FILE *);\n' +
+                'FILE *freopen(const char *, const char *, FILE *);\n' +
                 '#ifdef __cplusplus\n' +
                 '}\n' +
                 '#endif\n' +
@@ -6372,6 +6435,8 @@ del _webide_compiled, _webide_student_source
         }
         window.runAllTests = runAllTests;
 
+        // Exposed for tests/extensions that want to re-trigger after async runtimes settle.
+        window.checkAnswer = () => checkAnswer();
         async function checkAnswer() {
             console.log("Got feedback string: " + feedbackString);
             const points = {% if page.info.points %}{{page.info.points}}{% else %}0{% endif %};


### PR DESCRIPTION
## Summary

Mirrors the `_layouts/exercise.html` Jekyll template from the active WebIDE PR ([BillJr99/Ursinus-WebIDE#11](https://github.com/BillJr99/Ursinus-WebIDE/pull/11)) into this repo's `exercise.html` layout.

Source: WebIDE head `claude/enhance-student-debugging-tools-K5vuf` @ `18b1f8a`. Brings gutter breakpoint UI, per-file persistence, color-blind palette, and the pause-marker CSS scaffolding into the boilerplate exercise layout so downstream course sites get the same behavior.

This session is subscribed to WebIDE PR #11 and will push follow-up commits to this branch whenever new changes land on `_layouts/exercise.html` there.

## Test plan
- [ ] Visual diff against the WebIDE PR's `_layouts/exercise.html`
- [ ] Build a downstream course site that uses this layout and confirm breakpoints render

---
_Generated by [Claude Code](https://claude.ai/code/session_019SYPbpNTWx5W1j3LQZh2MR)_